### PR TITLE
docs: sync issue status with canonical specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,9 @@ Prioritize in this order:
 - `fix/` - bug fixes
 
 ## Current phase
-v0-demo shipped, issue #22 complete, and V2 foundation work is moving into workflow/schema/quality definition. Cells 0-7 remain stable and CI runs package-installed tests.
+v0-demo shipped, issues #22, #23, and #24 are complete and closed, and active V2 execution work is now concentrated in #27 and the remaining #6 to #9 foundation slices. Cells 0-7 remain stable and CI runs package-installed tests.
 
 ## Next session focus
 See [`docs/HANDOFF.md`](docs/HANDOFF.md) for full orientation and status.
 Execution roadmap lives in [`docs/ROADMAP.md`](docs/ROADMAP.md) and [`docs/V2_ISSUE_MAP.md`](docs/V2_ISSUE_MAP.md).
-Next priority: move to issue #23 after foundation completion, while continuing #6, #24, and #27 alignment work.
+Next priority: continue #27 operationalization plus the remaining #6, #7, #8, and #9 foundation work, then move downstream implementation into #10 onward.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ jupyter notebook notebooks/01_case_war_room.ipynb
 
 **Specified, not built yet:** `docs/V2_WORKFLOW_IA.md`, `docs/V2_EVIDENCE_SCHEMA.md`, and `docs/V2_RELEASE_RUBRIC.md` are the written source-of-truth specs for the current V2 planning layer, while `apps/`, `workers/`, and `packages/` remain placeholder boundaries for later implementation.
 
-Issues `#4`, `#5`, and `#22` are complete and closed. The written source-of-truth specs for `#23` and `#24` have landed locally in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard in `docs/V2_RELEASE_RUBRIC.md` and remains open for CI and pilot operationalization, issue `#6` is underway with slices 1-7 landed, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
+Issues `#4`, `#5`, `#22`, `#23`, and `#24` are complete and closed. The written source-of-truth specs for `#23` and `#24` live in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard in `docs/V2_RELEASE_RUBRIC.md` and remains open for CI and pilot operationalization, issue `#6` is underway with slices 1-7 landed, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
 
 ## Roadmap (Simple)
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -27,9 +27,9 @@ This is research acceleration, not legal advice.
 | Intake schema alignment (`#5`) | Complete and closed |
 | Typed domain contracts (#6) | Slices 1-7 complete (intake/query + packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts) |
 | Retrieval contracts (#7) | Four slices landed: provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing |
-| Product foundation (`#22`) | Complete: packaging/bootstrap lane implemented |
-| Workflow IA spec (`#23`) | Complete as the written source of truth in `docs/V2_WORKFLOW_IA.md` |
-| Evidence schema spec (`#24`) | Complete as the written source of truth in `docs/V2_EVIDENCE_SCHEMA.md` |
+| Product foundation (`#22`) | Complete and closed: packaging/bootstrap lane implemented |
+| Workflow IA spec (`#23`) | Complete and closed as the written source of truth in `docs/V2_WORKFLOW_IA.md` |
+| Evidence schema spec (`#24`) | Complete and closed as the written source of truth in `docs/V2_EVIDENCE_SCHEMA.md` |
 | Quality rubric (`#27`) | First-pass rubric plus local artifact workflow landed in `docs/V2_RELEASE_RUBRIC.md`; demo-ready threshold calibration is now explicit in the scorecard, while CI and pilot operationalization remain open |
 | Cache samples | Milton/Citizens/Pinellas + TX hail/Allstate/Tarrant + TX hail matching/Allstate Texas Lloyds/Tarrant DP-3 + Ida/Lloyd's/Orleans committed |
 

--- a/docs/PROJECT_HEALTH_AUDIT_2026-03-10.md
+++ b/docs/PROJECT_HEALTH_AUDIT_2026-03-10.md
@@ -55,7 +55,7 @@ Horizon: Next 2 weeks
 - Raw-checkout `pytest -q` is not a supported path. Contributors must either use editable install or set `PYTHONPATH=src`.
 - The placeholder `apps/`, `workers/`, and `packages/` directories can look more implemented than they are unless docs call that out directly.
 - The notebook is still the main demo surface. V2 app/api/workers are roadmap targets, not current runtime entrypoints.
-- `#23` and `#24` are complete as written specs. Downstream implementation belongs to `#10`, `#11`, and `#12`, plus remaining foundation work in `#6`, `#7`, `#8`, and `#9`.
+- `#23` and `#24` are complete and closed as written specs. Downstream implementation belongs to `#10`, `#11`, and `#12`, plus remaining foundation work in `#6`, `#7`, `#8`, and `#9`.
 
 ## Next 2 weeks action plan
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,10 +13,10 @@ This is the short version. Clean, practical, no drama.
 - The supported test path is editable install plus `pytest -q`, or `PYTHONPATH=src` for ad hoc local runs. Raw-checkout `pytest -q` is not supported.
 - The offline demo path now has a deterministic preflight command: `python -m war_room --preflight`.
 - A deeper V2 foundation layer is tracked in issues `#22` through `#27`.
-- Issue [#4](https://github.com/itprodirect/cat-loss-war-room-demo/issues/4) is complete.
+- Issue [#4](https://github.com/itprodirect/cat-loss-war-room-demo/issues/4) is complete and closed.
 - Issue [#5](https://github.com/itprodirect/cat-loss-war-room-demo/issues/5) is complete and closed.
-- Issue [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) is complete.
-- Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are complete as written source-of-truth specs.
+- Issue [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) is complete and closed.
+- Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are complete and closed as written source-of-truth specs.
 - Issue [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) is still open, but the local scorecard now includes explicit demo-ready threshold calibration in `docs/V2_RELEASE_RUBRIC.md`.
 - Issue [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) is in progress (slices 1-7 landed locally; review/export graph-linkage contract slice now added).
 - Placeholder directories under `apps/`, `packages/`, and `workers/` are planned V2 boundaries only. The active runtime remains the notebook plus `src/war_room/`.
@@ -32,7 +32,7 @@ This is the short version. Clean, practical, no drama.
 This is the current best-to-worst order for active work on the current build.
 Issue [#3](https://github.com/itprodirect/cat-loss-war-room-demo/issues/3) remains the umbrella epic and is not ranked with execution tickets.
 
-Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are not ranked here because their written source-of-truth docs already landed. Their downstream implementation work lives in `#10`, `#11`, and `#12`.
+Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are not ranked here because their written source-of-truth docs already landed and those definition issues are closed. Their downstream implementation work lives in `#10`, `#11`, and `#12`.
 
 1. [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) Refine and operationalize the first-pass quality rubric and release scorecard
 2. [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) Complete remaining typed domain contracts

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -900,3 +900,12 @@ Status: Complete
   - `$env:PYTHONPATH="src"; pytest -q` -> `197 passed`
   - `$env:PYTHONPATH="src"; python -m war_room --preflight --json` -> success (`scenario_count: 4`)
   - `$env:PYTHONPATH="src"; python -m war_room.release_scorecard --candidate codex/quality-hardening --verification-summary "197 passed"` -> success
+
+## Session 56 - Issue Status and Docs Sync
+Date: 2026-03-18
+Status: Complete
+
+- Audited the live GitHub issue tracker against the canonical roadmap docs after the merge back to `main`.
+- Confirmed issue drift: `#23` and `#24` were still open in GitHub even though the repo already treated them as completed written source-of-truth specs.
+- Synced the canonical status docs so `README.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/PROJECT_HEALTH_AUDIT_2026-03-10.md`, and `CLAUDE.md` all describe `#23` and `#24` as complete-and-closed definition issues.
+- Left `#27`, `#6`, `#7`, `#8`, and `#9` open because the docs still show real remaining implementation and operationalization scope.

--- a/docs/V2_ISSUE_MAP.md
+++ b/docs/V2_ISSUE_MAP.md
@@ -2,7 +2,7 @@
 
 This file maps V2 phases to GitHub issues so planning and execution stay aligned.
 
-Written source-of-truth specs for `#23` and `#24` are complete. Downstream implementation work continues in later issues; those docs should not be read as evidence that the V2 app/api/runtime already exists.
+Written source-of-truth specs for `#23` and `#24` are complete and those definition issues should remain closed. Downstream implementation work continues in later issues; those docs should not be read as evidence that the V2 app/api/runtime already exists.
 
 ## Phase 0: Stabilize V0 Baseline
 
@@ -16,9 +16,9 @@ Written source-of-truth specs for `#23` and `#24` are complete. Downstream imple
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Product foundation and repo shape | [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) | Completed Mar 6, 2026: packaging/bootstrap landed; app boundaries, envs, local dev, fixture lane documented |
-| Workflow IA and design system | [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) | Written spec complete in `docs/V2_WORKFLOW_IA.md`; downstream implementation belongs to `#10` and `#11` |
-| Canonical evidence graph and audit schema | [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) | Written spec complete in `docs/V2_EVIDENCE_SCHEMA.md`; downstream implementation belongs to `#6`, `#10`, `#11`, and `#12` |
+| Product foundation and repo shape | [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) | Completed and closed Mar 6, 2026: packaging/bootstrap landed; app boundaries, envs, local dev, fixture lane documented |
+| Workflow IA and design system | [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) | Written spec complete and issue closed in `docs/V2_WORKFLOW_IA.md`; downstream implementation belongs to `#10` and `#11` |
+| Canonical evidence graph and audit schema | [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) | Written spec complete and issue closed in `docs/V2_EVIDENCE_SCHEMA.md`; downstream implementation belongs to `#6`, `#10`, `#11`, and `#12` |
 | Quality rubric and release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) | First-pass rubric plus fixture-calibrated local scorecard now live in `docs/V2_RELEASE_RUBRIC.md`; explicit demo-ready thresholds are calibrated, and the next step is CI and pilot operationalization |
 
 ## Phase 2: Foundation and Quality Gates


### PR DESCRIPTION
Sync canonical docs so #23 and #24 are labeled complete and closed, close those finished GitHub issues to match the landed specs, and record the audit in the session log. Verification: PYTHONPATH=src pytest -q -> 197 passed.