### PR TITLE
docs: add missing memory front door

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,27 @@
+# Memory
+
+This file is the front door to the repo's existing memory stack. It points to the current operating docs and session history; it does not replace them.
+
+## Read order
+
+1. [README.md](./README.md)
+2. [AGENTS.md](./AGENTS.md)
+3. [docs/repo-brief.md](./docs/repo-brief.md)
+4. [docs/heartbeat.md](./docs/heartbeat.md)
+5. Latest file in [`logs/`](./logs/) (currently [`logs/2026-03-27-session.md`](./logs/2026-03-27-session.md))
+6. [docs/DECISION_LOG.md](./docs/DECISION_LOG.md) if the task touches a durable naming, scope, or architecture decision
+
+## Current operational memory files
+
+- [AGENTS.md](./AGENTS.md)
+- [docs/repo-brief.md](./docs/repo-brief.md)
+- [docs/heartbeat.md](./docs/heartbeat.md)
+- [`logs/`](./logs/)
+- [docs/DECISION_LOG.md](./docs/DECISION_LOG.md)
+
+## Update rules
+
+- Update [docs/heartbeat.md](./docs/heartbeat.md) when current-state status changes.
+- Add a file in [`logs/`](./logs/) for real work sessions worth resuming later.
+- Update [docs/repo-brief.md](./docs/repo-brief.md) when repo purpose, buyer/user, or current milestone changes.
+- Update [docs/DECISION_LOG.md](./docs/DECISION_LOG.md) only for durable naming, scope, or architecture decisions.

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -3,7 +3,7 @@
 - Repo: `cat-loss-war-room`
 - Current milestone: Stabilize the notebook demo while finishing `#27` and the remaining `#6` to `#9` foundation work.
 - Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; this session adds the memory stack only.
-- Current branch: `codex/foundation-focus-slices`
+- Current branch: `main`
 - Last validated: 2026-03-27 via `$env:PYTHONPATH='src'; .venv\Scripts\python.exe -m war_room --verify` (`252 passed`; offline preflight passed for 4 fixture scenarios)
 - Current focus: Keep docs and execution memory aligned without broadening scope beyond the current foundation tranche.
 - Hot files: `notebooks/01_case_war_room.ipynb`, `src/war_room/preflight.py`, `src/war_room/models.py`, `src/war_room/workflow_summary.py`, `src/war_room/evidence_board.py`, `src/war_room/issue_workspace.py`, `src/war_room/memo_composer.py`, `src/war_room/export_history.py`, `docs/V2_RELEASE_RUBRIC.md`


### PR DESCRIPTION
## Summary
- restore missing MEMORY.md onto main
- correct heartbeat branch entry to main

## Validation
- verified live repo identity is itprodirect/cat-loss-war-room
- verified PR #34 merged
- verified MEMORY.md was missing from main before this fix
- verified heartbeat on main still referenced codex/foundation-focus-slices