### PR TITLE
[codex] operationalize verify release evidence

### DIFF
--- a/docs/BUILD_CHECKLIST.md
+++ b/docs/BUILD_CHECKLIST.md
@@ -17,7 +17,7 @@ Simple execution checklist aligned with the live GitHub roadmap.
 - [x] [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) product foundation and repo shape
 - [x] [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) workflow IA and design system source of truth
 - [x] [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) canonical evidence graph and audit schema source of truth
-- [ ] [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) quality rubric and release scorecard (v0.1 rubric doc, local artifact generator, fixture-calibrated scenario coverage, explicit demo-ready thresholds, and CI artifact emission plus validation landed; pilot operationalization still needed)
+- [ ] [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) quality rubric and release scorecard (v0.1 rubric doc, local artifact generator, fixture-calibrated scenario coverage, explicit demo-ready thresholds, CI artifact emission plus validation, and `python -m war_room --verify` scorecard emission with live preflight evidence plus linked run-scoped preflight artifacts, verify manifests, a stable `runs/verify/latest.json` pointer, and an end-to-end artifact consistency guard landed; pilot operationalization still needed)
 
 ## Immediate Execution Priorities
 

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1334,3 +1334,127 @@ Status: Complete
 - Verification:
   - `$env:PYTHONPATH='src'; .venv\Scripts\python.exe -m pytest tests/test_caselaw.py tests/test_offline_demo_pack.py -q` -> `50 passed, 1 warning`
   - `$env:PYTHONPATH='src'; .venv\Scripts\python.exe -m war_room --verify` -> passed, `268 passed, 1 warning`; offline preflight passed for 4 committed fixture scenarios
+
+## Session 75 - Verify Command Release Scorecard Emission
+Date: 2026-04-18
+Status: Complete
+
+- Tightened the `#27` local operational path by making the supported verification command emit release-scorecard artifacts directly instead of requiring a second manual command after verification passes.
+- What changed:
+  - `src/war_room/bootstrap.py` now accepts an optional `--release-candidate` override for `python -m war_room --verify`.
+  - Successful verify runs now capture the pytest result summary, resolve a candidate label from the current branch when available, and write paired JSON/Markdown release-scorecard artifacts into `runs/release_scorecards/`.
+  - When branch detection is unavailable or detached, the verify path falls back to `local-verify` instead of failing the supported command.
+  - `tests/test_bootstrap.py` now covers verify-path scorecard emission, candidate override/fallback behavior, and pytest summary extraction.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the one-command local release-evidence flow while keeping the standalone scorecard CLI documented for CI/manual use.
+- Why:
+  - `#27` already had a rubric, local scorecard generator, and CI artifact job, but the supported local verification path still required a second manual step to create matching release evidence.
+  - Wiring scorecard emission into `python -m war_room --verify` makes the documented contributor path closer to the actual release-readiness workflow without changing notebook-era runtime behavior.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py -q` -> `15 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `272 passed`; offline preflight passed for 4 committed fixture scenarios; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify.*`
+
+## Session 76 - Release Scorecard Live Preflight Evidence
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` operationalization path by teaching verify-driven scorecards to record the actual offline preflight result instead of inferring the offline gate only from committed fixture presence.
+- What changed:
+  - `src/war_room/release_scorecard.py` now defines a structured preflight summary, can summarize `DemoPreflightReport`, and includes an `Offline Preflight` section in Markdown artifacts when live preflight evidence is available.
+  - The scorecard's `Offline demo lane completes` must-pass gate now uses the live preflight result when `python -m war_room --verify` generated the artifact, while the standalone scorecard CLI still falls back to fixture-based evidence.
+  - `src/war_room/bootstrap.py` now passes the already-computed preflight report into scorecard generation so the verify path produces one coherent release-evidence artifact.
+  - `tests/test_release_scorecard.py` and `tests/test_bootstrap.py` now cover preflight-summary capture, failed preflight gating, and verify-path handoff of the live report.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the live-preflight-backed verify workflow.
+- Why:
+  - the previous slice made `python -m war_room --verify` emit scorecards automatically, but the offline-lane gate inside the artifact still depended on fixture coverage instead of the actual preflight result from that same run.
+  - this keeps the artifact closer to real release evidence without broadening scope into new CI layers or changing notebook runtime behavior.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `21 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `274 passed`; offline preflight passed for 4 committed fixture scenarios; scorecard artifacts refreshed under `runs/release_scorecards/2026-04-18_local-verify.*`
+
+## Session 77 - Linked Preflight Artifacts For Verify
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` evidence path by persisting the live preflight payload from `python -m war_room --verify` and linking that artifact from the release scorecard.
+- What changed:
+  - `src/war_room/preflight.py` now writes machine-readable preflight JSON artifacts under `runs/preflight/`.
+  - `src/war_room/bootstrap.py` now writes that preflight artifact during `--verify`, prints its path, and passes the path into scorecard generation.
+  - `src/war_room/release_scorecard.py` now records `preflight_artifact_path` in the structured scorecard artifact and surfaces it in the Markdown evidence bundle.
+  - `tests/test_preflight.py`, `tests/test_bootstrap.py`, and `tests/test_release_scorecard.py` now cover preflight artifact writing, verify-path handoff, and scorecard-path persistence.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the linked preflight-artifact workflow.
+- Why:
+  - the prior slice summarized the live preflight result inside the scorecard, but the scorecard still did not point to the exact machine-readable offline artifact produced by that verify run.
+  - this keeps release evidence auditable without adding new dependencies or broadening scope into CI redesign.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `22 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `275 passed`; offline preflight passed for 4 committed fixture scenarios; preflight artifact written under `runs/preflight/2026-04-18_local-verify.json`; scorecard artifacts refreshed under `runs/release_scorecards/2026-04-18_local-verify.*`
+
+## Session 78 - Shared Run Id For Verify Evidence
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` release-evidence path by making verify-generated preflight and scorecard artifacts run-scoped instead of day-scoped.
+- What changed:
+  - `src/war_room/preflight.py` now accepts a shared `run_id` when writing artifacts, stores that `run_id` in the preflight JSON payload, and includes it in the artifact filename.
+  - `src/war_room/release_scorecard.py` now records `run_id` on the structured scorecard artifact and includes that `run_id` in scorecard filenames and Markdown output.
+  - `src/war_room/bootstrap.py` now resolves one shared run id from the live preflight timestamp and uses it for both the preflight artifact and the scorecard artifact during `python -m war_room --verify`.
+  - `tests/test_preflight.py`, `tests/test_release_scorecard.py`, and `tests/test_bootstrap.py` now cover the shared run id, the new filename shapes, and the persisted payload fields.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the run-scoped verify artifact flow.
+- Why:
+  - the prior slice linked the preflight artifact from the scorecard, but repeated verify runs on the same day for the same candidate still overwrote the prior evidence files.
+  - adding a shared run id keeps the preflight and scorecard artifacts paired while making repeated validations auditable instead of lossy.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `22 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `275 passed`; offline preflight passed for 4 committed fixture scenarios; preflight artifact written under `runs/preflight/2026-04-18_local-verify_20260418t162818z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify_20260418t162818z.*`
+
+## Session 79 - Verify Run Manifest
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` release-evidence path by adding a single verify-run manifest that points to the exact artifacts generated by each supported `--verify` run.
+- What changed:
+  - `src/war_room/bootstrap.py` now writes a JSON manifest into `runs/verify/` after the preflight and scorecard artifacts are written.
+  - The verify manifest records `run_id`, `created_at`, `candidate`, `verification_summary`, `repo_root`, and the exact preflight / scorecard artifact paths for that run.
+  - Verify console output now prints a dedicated `Verify Manifest` section before the preflight and scorecard paths.
+  - `tests/test_bootstrap.py` now covers manifest creation and ensures failed test runs do not write a manifest.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the new `runs/verify/` top-level evidence pointer.
+- Why:
+  - the previous slice made preflight and scorecard artifacts collision-safe, but there was still no single machine-readable file that indexed the whole verify run.
+  - the manifest makes each verify run queryable without scanning multiple directories or reconstructing artifact relationships from filenames.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `22 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `275 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_local-verify_20260418t163443z.json`; preflight artifact written under `runs/preflight/2026-04-18_local-verify_20260418t163443z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify_20260418t163443z.*`
+
+## Session 80 - Latest Verify Pointer
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` release-evidence path by adding a stable discovery pointer for the newest successful supported verify run.
+- What changed:
+  - `src/war_room/bootstrap.py` now writes `runs/verify/latest.json` after each successful verify manifest write.
+  - The latest pointer records the newest verify `run_id`, `created_at`, `candidate`, and the exact manifest path to follow for the full evidence bundle.
+  - Verify console output now surfaces the `latest.json` path directly in the `Verify Manifest` section.
+  - `tests/test_bootstrap.py` now covers latest-pointer emission during successful verify runs, the guard that failed runs do not write it, and the concrete `latest.json` payload shape.
+  - `docs/V2_RELEASE_RUBRIC.md` and `docs/BUILD_CHECKLIST.md` now describe the stable verify discovery pointer.
+- Why:
+  - the previous slice made each verify run queryable through its own manifest, but consumers still had to scan `runs/verify/` to find the newest run.
+  - `latest.json` keeps the current workflow simple while giving downstream tooling one stable file to open first.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `23 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `276 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_local-verify_20260418t164252z.json`; latest pointer refreshed at `runs/verify/latest.json`; preflight artifact written under `runs/preflight/2026-04-18_local-verify_20260418t164252z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify_20260418t164252z.*`
+
+## Session 81 - Verify Artifact Consistency Guard
+Date: 2026-04-18
+Status: Complete
+
+- Continued the `#27` release-evidence path by adding an end-to-end test that reloads the verify manifest and checks the linked artifact bundle for consistency.
+- What changed:
+  - `tests/test_bootstrap.py` now writes a real preflight artifact, a real release scorecard artifact, and a real verify manifest into a temporary `runs/` tree during one focused test.
+  - That test reloads the manifest JSON, asserts the linked preflight and scorecard artifact paths exist, and verifies that the manifest, preflight payload, and scorecard payload all share the same `run_id`.
+  - `docs/BUILD_CHECKLIST.md` now notes that the end-to-end artifact consistency guard has landed in the local `#27` verification path.
+- Why:
+  - the previous slice made the newest verify run easy to discover through `runs/verify/latest.json`, but there was still no explicit regression guard proving that the manifest and its linked artifacts stayed internally consistent.
+  - this gives the release-evidence workflow one concrete integrity check before packaging the PR.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `24 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_local-verify_20260418t164745z.json`; latest pointer refreshed at `runs/verify/latest.json`; preflight artifact written under `runs/preflight/2026-04-18_local-verify_20260418t164745z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify_20260418t164745z.*`

--- a/docs/V2_RELEASE_RUBRIC.md
+++ b/docs/V2_RELEASE_RUBRIC.md
@@ -1,6 +1,6 @@
 # V2 Quality Rubric and Release Scorecard
 
-Last updated: March 18, 2026
+Last updated: April 18, 2026
 
 This document is the first-pass output of issue `#27`.
 
@@ -348,29 +348,42 @@ Use this template for future release candidates.
 
 The rubric now has a lightweight local operational path.
 
-After running the supported verification command, generate a scorecard artifact with:
+The supported verification command now writes a paired scorecard artifact automatically:
+
+```bash
+python -m war_room --verify
+```
+
+Optional candidate override for local release evidence:
+
+```bash
+python -m war_room --verify --release-candidate local-demo
+```
+
+What this does now:
+
+- runs the deterministic offline preflight and the supported `pytest -q` path
+- writes Markdown and JSON scorecard artifacts into `runs/release_scorecards/`
+- writes the underlying machine-readable offline preflight payload into `runs/preflight/`
+- assigns a shared run id to the preflight and scorecard artifacts so repeated same-day verify runs do not overwrite each other
+- writes a verify-run manifest into `runs/verify/` that points to the exact preflight and scorecard artifacts for that run
+- refreshes `runs/verify/latest.json` so downstream tooling can discover the newest successful verify run without scanning filenames
+- records the current demo-ready baseline in a repeatable format from the same supported local verification command
+- records the live offline preflight result in the scorecard artifact, so the offline-lane gate is tied to the actual `--verify` run rather than fixture coverage alone
+- records that shared run id and the preflight artifact path in the scorecard JSON/Markdown so release evidence can be traced back to the exact offline run
+- captures committed fixture coverage from `cache_samples/` so the scorecard reflects the live offline scenario set
+- surfaces scenario-registry and offline-ready coverage alongside committed fixture coverage
+- evaluates explicit demo-ready fixture thresholds inside the artifact
+- runs in CI, validates the ship thresholds, and uploads the same artifact from the release-scorecard job
+- creates a concrete artifact that later `#9` CI work can extend beyond the current demo-ready gate
+
+Manual and CI-specific scorecard generation still remains available with:
 
 ```bash
 python -m war_room.release_scorecard \
   --candidate local-demo \
   --verification-summary "252 passed"
 ```
-
-Default verification command recorded in the artifact:
-
-```bash
-pytest -q
-```
-
-What this does now:
-
-- writes Markdown and JSON scorecard artifacts into `runs/release_scorecards/`
-- records the current demo-ready baseline in a repeatable format
-- captures committed fixture coverage from `cache_samples/` so the scorecard reflects the live offline scenario set
-- surfaces scenario-registry and offline-ready coverage alongside committed fixture coverage
-- evaluates explicit demo-ready fixture thresholds inside the artifact
-- runs in CI, validates the ship thresholds, and uploads the same artifact from the release-scorecard job
-- creates a concrete artifact that later `#9` CI work can extend beyond the current demo-ready gate
 
 What it does not do yet:
 

--- a/src/war_room/bootstrap.py
+++ b/src/war_room/bootstrap.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from war_room.settings import WarRoomSettings, load_settings
@@ -18,6 +18,31 @@ class BootstrapContext:
 
     repo_root: Path
     settings: WarRoomSettings
+
+
+@dataclass(frozen=True)
+class VerifyRunManifest:
+    """One verify-run manifest tying generated evidence artifacts together."""
+
+    run_id: str
+    created_at: str
+    candidate: str
+    verification_command: str
+    verification_summary: str
+    repo_root: str
+    preflight_artifact_path: str
+    release_scorecard_json_path: str
+    release_scorecard_markdown_path: str
+
+
+@dataclass(frozen=True)
+class LatestVerifyPointer:
+    """Stable pointer to the newest successful verify-run manifest."""
+
+    run_id: str
+    created_at: str
+    candidate: str
+    verify_manifest_path: str
 
 
 def discover_repo_root(start_path: Path | None = None) -> Path:
@@ -65,6 +90,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run the supported local verification path (preflight + pytest -q)",
     )
+    parser.add_argument(
+        "--release-candidate",
+        help="Optional release-scorecard candidate label for --verify. Defaults to the current branch when available.",
+    )
     parser.add_argument("--json", action="store_true", help="Print the resolved settings as JSON")
     args = parser.parse_args(argv)
 
@@ -82,7 +111,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0 if report.passed else 1
 
     if args.verify:
-        return _run_supported_verification(context)
+        return _run_supported_verification(context, release_candidate=args.release_candidate)
 
     if args.json:
         print(json.dumps(summary, indent=2))
@@ -95,7 +124,11 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-def _run_supported_verification(context: BootstrapContext) -> int:
+def _run_supported_verification(
+    context: BootstrapContext,
+    *,
+    release_candidate: str | None = None,
+) -> int:
     """Run the deterministic offline preflight plus the supported pytest command."""
     from war_room.preflight import render_demo_preflight_report, run_demo_preflight
 
@@ -113,14 +146,237 @@ def _run_supported_verification(context: BootstrapContext) -> int:
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "-q"],
         cwd=context.repo_root,
+        capture_output=True,
         check=False,
+        text=True,
     )
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+    verification_summary = _extract_pytest_summary(result.stdout, result.stderr)
+    if not verification_summary:
+        verification_summary = f"pytest exited with code {result.returncode}"
     if result.returncode:
         print(f"Verification failed: pytest exited with code {result.returncode}.")
         return result.returncode
 
+    candidate = _resolve_release_candidate(context, override=release_candidate)
+    run_id = _resolve_verify_run_id(report)
+    try:
+        preflight_artifact_path = _write_verify_preflight_artifact(
+            context,
+            candidate=candidate,
+            preflight_report=report,
+            run_id=run_id,
+        )
+        scorecard_json_path, scorecard_markdown_path = _write_verify_release_scorecard(
+            context,
+            candidate=candidate,
+            run_id=run_id,
+            verification_summary=verification_summary,
+            preflight_report=report,
+            preflight_artifact_path=preflight_artifact_path,
+        )
+        verify_manifest_path = _write_verify_manifest(
+            context,
+            run_id=run_id,
+            created_at=report.created_at,
+            candidate=candidate,
+            verification_summary=verification_summary,
+            preflight_artifact_path=preflight_artifact_path,
+            release_scorecard_json_path=scorecard_json_path,
+            release_scorecard_markdown_path=scorecard_markdown_path,
+        )
+        latest_verify_pointer_path = _write_latest_verify_pointer(
+            context,
+            run_id=run_id,
+            created_at=report.created_at,
+            candidate=candidate,
+            verify_manifest_path=verify_manifest_path,
+        )
+    except Exception as exc:  # pragma: no cover - defensive failure path
+        print(f"Verification failed: could not write verification artifacts ({type(exc).__name__}: {exc}).")
+        return 1
+
+    print("## Verify Manifest")
+    print(f"- JSON: {verify_manifest_path}")
+    print(f"- Latest: {latest_verify_pointer_path}")
+    print("## Preflight Artifact")
+    print(f"- Run id: {run_id}")
+    print(f"- JSON: {preflight_artifact_path}")
+    print("## Release Scorecard")
+    print(f"- Candidate: {candidate}")
+    print(f"- JSON: {scorecard_json_path}")
+    print(f"- Markdown: {scorecard_markdown_path}")
     print("Verification passed.")
     return 0
+
+
+def _resolve_release_candidate(
+    context: BootstrapContext,
+    *,
+    override: str | None = None,
+) -> str:
+    """Resolve the release-scorecard candidate label for a local verify run."""
+
+    if override:
+        return override.strip() or "local-verify"
+
+    result = subprocess.run(
+        [
+            "git",
+            f"-c",
+            f"safe.directory={context.repo_root}",
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        ],
+        cwd=context.repo_root,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    branch = result.stdout.strip()
+    if result.returncode == 0 and branch and branch.upper() != "HEAD":
+        return branch
+    return "local-verify"
+
+
+def _write_verify_release_scorecard(
+    context: BootstrapContext,
+    *,
+    candidate: str,
+    run_id: str,
+    verification_summary: str,
+    preflight_report,
+    preflight_artifact_path: Path,
+) -> tuple[Path, Path]:
+    """Write the release-scorecard artifact paired with a successful verify run."""
+
+    from war_room.release_scorecard import (
+        build_demo_release_scorecard,
+        collect_fixture_coverage,
+        collect_scenario_registry_coverage,
+        summarize_preflight_report,
+        write_release_scorecard_artifacts,
+    )
+
+    fixture_coverage = collect_fixture_coverage(context.settings.cache_samples_dir)
+    scenario_registry = collect_scenario_registry_coverage(context.repo_root, context.settings.cache_samples_dir)
+    scorecard = build_demo_release_scorecard(
+        run_id=run_id,
+        candidate=candidate,
+        verification_summary=verification_summary,
+        preflight_artifact_path=str(preflight_artifact_path),
+        preflight_summary=summarize_preflight_report(preflight_report),
+        fixture_coverage=fixture_coverage,
+        scenario_registry=scenario_registry,
+    )
+    output_dir = context.settings.runs_dir / "release_scorecards"
+    return write_release_scorecard_artifacts(scorecard, output_dir=output_dir)
+
+
+def _write_verify_preflight_artifact(
+    context: BootstrapContext,
+    *,
+    candidate: str,
+    preflight_report,
+    run_id: str,
+) -> Path:
+    """Persist the live preflight report for the verify run."""
+
+    from war_room.preflight import write_preflight_artifact
+
+    output_dir = context.settings.runs_dir / "preflight"
+    return write_preflight_artifact(
+        preflight_report,
+        output_dir=output_dir,
+        artifact_label=candidate,
+        run_id=run_id,
+    )
+
+
+def _resolve_verify_run_id(preflight_report) -> str:
+    """Return the shared run id for verify-generated artifacts."""
+
+    from war_room.preflight import preflight_run_id
+
+    return preflight_run_id(preflight_report)
+
+
+def _write_verify_manifest(
+    context: BootstrapContext,
+    *,
+    run_id: str,
+    created_at: str,
+    candidate: str,
+    verification_summary: str,
+    preflight_artifact_path: Path,
+    release_scorecard_json_path: Path,
+    release_scorecard_markdown_path: Path,
+) -> Path:
+    """Persist one machine-readable manifest for the verify run."""
+
+    manifest = VerifyRunManifest(
+        run_id=run_id,
+        created_at=created_at,
+        candidate=candidate,
+        verification_command="pytest -q",
+        verification_summary=verification_summary,
+        repo_root=str(context.repo_root),
+        preflight_artifact_path=str(preflight_artifact_path),
+        release_scorecard_json_path=str(release_scorecard_json_path),
+        release_scorecard_markdown_path=str(release_scorecard_markdown_path),
+    )
+    output_dir = context.settings.runs_dir / "verify"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{created_at[:10]}_{_slugify_verify_label(candidate)}_{run_id.lower()}"
+    output_path = output_dir / f"{stem}.json"
+    output_path.write_text(json.dumps(asdict(manifest), indent=2), encoding="utf-8")
+    return output_path
+
+
+def _write_latest_verify_pointer(
+    context: BootstrapContext,
+    *,
+    run_id: str,
+    created_at: str,
+    candidate: str,
+    verify_manifest_path: Path,
+) -> Path:
+    """Persist a stable pointer to the newest successful verify-run manifest."""
+
+    latest_pointer = LatestVerifyPointer(
+        run_id=run_id,
+        created_at=created_at,
+        candidate=candidate,
+        verify_manifest_path=str(verify_manifest_path),
+    )
+    output_dir = context.settings.runs_dir / "verify"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "latest.json"
+    output_path.write_text(json.dumps(asdict(latest_pointer), indent=2), encoding="utf-8")
+    return output_path
+
+
+def _extract_pytest_summary(stdout: str, stderr: str) -> str:
+    """Extract the final pytest result summary from captured command output."""
+
+    summary_tokens = ("passed", "failed", "error", "errors", "skipped", "warning", "warnings", "xfailed", "xpassed")
+    lines = [line.strip() for line in f"{stdout}\n{stderr}".splitlines() if line.strip()]
+    for line in reversed(lines):
+        normalized = line.lower()
+        if any(token in normalized for token in summary_tokens):
+            return line
+    return ""
+
+
+def _slugify_verify_label(value: str) -> str:
+    normalized = "".join(char.lower() if char.isalnum() else "-" for char in value.strip())
+    collapsed = "-".join(part for part in normalized.split("-") if part)
+    return collapsed or "verify"
 
 
 if __name__ == "__main__":

--- a/src/war_room/preflight.py
+++ b/src/war_room/preflight.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, UTC
 from pathlib import Path
@@ -376,6 +377,31 @@ def report_to_payload(report: DemoPreflightReport) -> dict[str, Any]:
     }
 
 
+def write_preflight_artifact(
+    report: DemoPreflightReport,
+    *,
+    output_dir: Path,
+    artifact_label: str | None = None,
+    run_id: str | None = None,
+) -> Path:
+    """Write the machine-readable preflight payload to disk."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved_run_id = run_id or preflight_run_id(report)
+    stem = _preflight_artifact_stem(report, artifact_label=artifact_label, run_id=resolved_run_id)
+    output_path = output_dir / f"{stem}.json"
+    payload = report_to_payload(report) | {"run_id": resolved_run_id}
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return output_path
+
+
+def preflight_run_id(report: DemoPreflightReport) -> str:
+    """Return a stable run id for the preflight report timestamp."""
+
+    created_at = datetime.fromisoformat(report.created_at.replace("Z", "+00:00")).astimezone(UTC)
+    return created_at.strftime("%Y%m%dT%H%M%SZ")
+
+
 def _discover_scenario_dirs(cache_samples_dir: Path) -> list[Path]:
     if not cache_samples_dir.exists():
         return []
@@ -475,3 +501,21 @@ def _memo_checks(memo: str, memo_sections: list[str]) -> list[PreflightCheck]:
         ),
     ]
     return checks
+
+
+def _preflight_artifact_stem(
+    report: DemoPreflightReport,
+    *,
+    artifact_label: str | None = None,
+    run_id: str,
+) -> str:
+    created_at = datetime.fromisoformat(report.created_at.replace("Z", "+00:00"))
+    date_prefix = created_at.date().isoformat()
+    if artifact_label:
+        return f"{date_prefix}_{_slugify_artifact_label(artifact_label)}_{run_id.lower()}"
+    return f"{date_prefix}_{run_id.lower()}"
+
+
+def _slugify_artifact_label(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized or "preflight"

--- a/src/war_room/release_scorecard.py
+++ b/src/war_room/release_scorecard.py
@@ -6,10 +6,11 @@ import argparse
 import json
 import re
 from dataclasses import asdict, dataclass, field
-from datetime import date
+from datetime import date, datetime, UTC
 from pathlib import Path
 
 from war_room.bootstrap import bootstrap_runtime
+from war_room.preflight import DemoPreflightReport
 from war_room.scenarios import default_scenario_id as get_default_scenario_id, list_scenarios
 
 DEFAULT_VERIFICATION_COMMAND = "pytest -q"
@@ -94,14 +95,40 @@ class CalibrationThreshold:
 
 
 @dataclass(frozen=True)
+class PreflightScenarioSummary:
+    """One scenario outcome from the live offline preflight lane."""
+
+    case_key: str
+    passed: bool
+    workflow_status: str
+    workflow_review_required: bool
+    availability_status: str
+    failed_checks: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PreflightSummary:
+    """Structured summary of the live offline preflight run."""
+
+    passed: bool
+    scenario_count: int
+    passed_scenario_count: int
+    scenario_keys: list[str]
+    scenarios: list[PreflightScenarioSummary]
+
+
+@dataclass(frozen=True)
 class ReleaseScorecard:
     """Structured release scorecard artifact."""
 
+    run_id: str
     date: str
     candidate: str
     target_release_level: str
     evaluators: list[str]
     evidence_bundle: list[str]
+    preflight_artifact_path: str | None
+    preflight_summary: PreflightSummary | None
     fixture_coverage: FixtureCoverageSummary | None
     scenario_registry: ScenarioRegistrySummary | None
     calibration_thresholds: list[CalibrationThreshold]
@@ -184,27 +211,58 @@ def collect_scenario_registry_coverage(
     )
 
 
+def summarize_preflight_report(report: DemoPreflightReport) -> PreflightSummary:
+    """Collapse the live preflight report into scorecard-friendly evidence."""
+
+    scenarios = [
+        PreflightScenarioSummary(
+            case_key=scenario.case_key,
+            passed=all(check.passed for check in scenario.checks),
+            workflow_status=scenario.workflow_status,
+            workflow_review_required=scenario.workflow_review_required,
+            availability_status=scenario.availability.status,
+            failed_checks=[check.name for check in scenario.checks if not check.passed],
+        )
+        for scenario in report.scenarios
+    ]
+    return PreflightSummary(
+        passed=report.passed,
+        scenario_count=report.scenario_count,
+        passed_scenario_count=sum(1 for scenario in scenarios if scenario.passed),
+        scenario_keys=[scenario.case_key for scenario in scenarios],
+        scenarios=scenarios,
+    )
+
+
 def build_demo_release_scorecard(
     *,
     candidate: str,
     verification_summary: str,
     verification_command: str = DEFAULT_VERIFICATION_COMMAND,
     artifact_date: str | None = None,
+    run_id: str | None = None,
     evaluators: list[str] | None = None,
     blocking_gaps: list[str] | None = None,
     decision: str = "Ship",
+    preflight_artifact_path: str | None = None,
+    preflight_summary: PreflightSummary | None = None,
     fixture_coverage: FixtureCoverageSummary | None = None,
     scenario_registry: ScenarioRegistrySummary | None = None,
 ) -> ReleaseScorecard:
     """Build the current demo-ready baseline scorecard."""
 
     chosen_date = artifact_date or date.today().isoformat()
+    resolved_run_id = run_id or _default_run_id()
     verification_passed = _verification_summary_passed(verification_summary)
     calibration_thresholds = _build_demo_ready_thresholds(fixture_coverage)
     thresholds_passed = all(threshold.passed for threshold in calibration_thresholds)
+    offline_demo_passed = preflight_summary.passed if preflight_summary else bool(
+        fixture_coverage and fixture_coverage.scenario_count
+    )
+    offline_preflight_evidence = _preflight_evidence(preflight_summary)
     evidence_bundle = [
         f"Verification: {verification_command} -> {verification_summary}",
-        "Offline demo lane uses committed cache_samples fixtures.",
+        offline_preflight_evidence,
         "Rubric source of truth: docs/V2_RELEASE_RUBRIC.md",
     ]
     if fixture_coverage and fixture_coverage.scenario_count:
@@ -230,7 +288,7 @@ def build_demo_release_scorecard(
 
     reliability_evidence = [
         f"Supported verification path passed ({verification_summary}).",
-        "Offline demo lane is established with committed fixtures.",
+        offline_preflight_evidence,
     ]
     evidence_quality_evidence = [
         "Evidence quality is calibrated against explicit committed-fixture thresholds instead of narrative-only baseline text.",
@@ -239,6 +297,10 @@ def build_demo_release_scorecard(
         "Bootstrap and runtime boundaries are documented.",
         "This script now emits repeatable local scorecard artifacts into runs/.",
     ]
+    if preflight_summary:
+        operational_evidence.append(
+            "Verify-driven scorecards now record the live offline preflight result alongside fixture calibration."
+        )
     if fixture_coverage and fixture_coverage.scenario_count:
         fixture_line = (
             f"Committed fixture lane now spans {fixture_coverage.scenario_count} scenarios "
@@ -267,8 +329,24 @@ def build_demo_release_scorecard(
     dimensions = [
         ScorecardDimension(
             name="Reliability",
-            score=3 if verification_passed and thresholds_passed else 2 if verification_passed else 0,
-            verdict="Strong" if verification_passed and thresholds_passed else "Acceptable" if verification_passed else "Blocked",
+            score=(
+                3
+                if verification_passed and offline_demo_passed and thresholds_passed
+                else 2
+                if verification_passed and offline_demo_passed
+                else 1
+                if verification_passed
+                else 0
+            ),
+            verdict=(
+                "Strong"
+                if verification_passed and offline_demo_passed and thresholds_passed
+                else "Acceptable"
+                if verification_passed and offline_demo_passed
+                else "Weak"
+                if verification_passed
+                else "Blocked"
+            ),
             evidence=reliability_evidence,
             notes="Fresh-env and exa-py compatibility CI gates exist, and the scorecard now evaluates the supported verification lane against explicit demo-ready fixture thresholds.",
         ),
@@ -335,8 +413,8 @@ def build_demo_release_scorecard(
         ),
         MustPassGate(
             name="Offline demo lane completes",
-            passed=bool(fixture_coverage and fixture_coverage.scenario_count),
-            evidence=_offline_gate_evidence(fixture_coverage),
+            passed=offline_demo_passed,
+            evidence=_offline_gate_evidence(fixture_coverage, preflight_summary),
         ),
         MustPassGate(
             name="Committed fixture coverage meets demo-ready threshold",
@@ -367,11 +445,14 @@ def build_demo_release_scorecard(
             merged_blocking_gaps.append(gap)
 
     return ReleaseScorecard(
+        run_id=resolved_run_id,
         date=chosen_date,
         candidate=candidate,
         target_release_level="Demo-ready",
         evaluators=evaluators or ["local builder"],
         evidence_bundle=evidence_bundle,
+        preflight_artifact_path=preflight_artifact_path,
+        preflight_summary=preflight_summary,
         fixture_coverage=fixture_coverage,
         scenario_registry=scenario_registry,
         calibration_thresholds=calibration_thresholds,
@@ -388,6 +469,7 @@ def render_release_scorecard_markdown(scorecard: ReleaseScorecard) -> str:
     lines = [
         "# Release Scorecard",
         "",
+        f"- Run id: {scorecard.run_id}",
         f"- Date: {scorecard.date}",
         f"- Candidate / branch: {scorecard.candidate}",
         f"- Target release level: {scorecard.target_release_level}",
@@ -396,6 +478,30 @@ def render_release_scorecard_markdown(scorecard: ReleaseScorecard) -> str:
     ]
     for entry in scorecard.evidence_bundle:
         lines.append(f"  - {entry}")
+    if scorecard.preflight_artifact_path:
+        lines.append(f"  - Preflight artifact: {scorecard.preflight_artifact_path}")
+
+    if scorecard.preflight_summary and scorecard.preflight_summary.scenario_count:
+        lines.extend(
+            [
+                "",
+                "## Offline Preflight",
+                f"- Passed: {'Yes' if scorecard.preflight_summary.passed else 'No'}",
+                (
+                    f"- Scenario coverage: {scorecard.preflight_summary.passed_scenario_count}/"
+                    f"{scorecard.preflight_summary.scenario_count} scenarios passed"
+                ),
+            ]
+        )
+        for scenario in scorecard.preflight_summary.scenarios:
+            failed_checks = ", ".join(scenario.failed_checks) if scenario.failed_checks else "none"
+            lines.append(
+                f"- {scenario.case_key}: {'passed' if scenario.passed else 'failed'} | "
+                f"workflow {scenario.workflow_status or 'unknown'} | "
+                f"availability {scenario.availability_status} | "
+                f"review_required {'yes' if scenario.workflow_review_required else 'no'} | "
+                f"failed checks: {failed_checks}"
+            )
 
     if scorecard.fixture_coverage and scorecard.fixture_coverage.scenario_count:
         lines.extend(
@@ -483,7 +589,7 @@ def write_release_scorecard_artifacts(
     """Write JSON and Markdown scorecard artifacts."""
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    stem = f"{scorecard.date}_{_slugify(scorecard.candidate)}"
+    stem = f"{scorecard.date}_{_slugify(scorecard.candidate)}_{scorecard.run_id.lower()}"
     json_path = output_dir / f"{stem}.json"
     markdown_path = output_dir / f"{stem}.md"
 
@@ -573,7 +679,26 @@ def _clean_fixture_text(value: str) -> str:
     )
 
 
-def _offline_gate_evidence(fixture_coverage: FixtureCoverageSummary | None) -> str:
+def _preflight_evidence(preflight_summary: PreflightSummary | None) -> str:
+    if not preflight_summary:
+        return "Offline demo lane uses committed cache_samples fixtures."
+    return (
+        "Offline preflight: "
+        f"{preflight_summary.passed_scenario_count}/{preflight_summary.scenario_count} "
+        "committed scenarios passed."
+    )
+
+
+def _offline_gate_evidence(
+    fixture_coverage: FixtureCoverageSummary | None,
+    preflight_summary: PreflightSummary | None = None,
+) -> str:
+    if preflight_summary:
+        return (
+            "Live offline preflight result: "
+            f"{preflight_summary.passed_scenario_count}/{preflight_summary.scenario_count} "
+            f"scenarios passed ({', '.join(preflight_summary.scenario_keys)})."
+        )
     if not fixture_coverage or not fixture_coverage.scenario_count:
         return "Committed cache_samples fixtures support the offline demo lane."
     return (
@@ -642,6 +767,10 @@ def _verification_summary_passed(summary: str) -> bool:
 def _slugify(value: str) -> str:
     normalized = re.sub(r"[^A-Za-z0-9]+", "-", value.strip().lower()).strip("-")
     return normalized or "candidate"
+
+
+def _default_run_id() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
 
 
 if __name__ == "__main__":

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,12 +1,31 @@
 """Tests for repo bootstrap helpers."""
 
+import json
 import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
 
-from war_room.bootstrap import bootstrap_runtime, discover_repo_root, main as bootstrap_main
+from war_room.bootstrap import (
+    _extract_pytest_summary,
+    _write_latest_verify_pointer,
+    _write_verify_manifest,
+    _resolve_release_candidate,
+    bootstrap_runtime,
+    discover_repo_root,
+    main as bootstrap_main,
+)
+from war_room.preflight import preflight_run_id, run_demo_preflight, write_preflight_artifact
+from war_room.release_scorecard import (
+    build_demo_release_scorecard,
+    collect_fixture_coverage,
+    collect_scenario_registry_coverage,
+    summarize_preflight_report,
+    write_release_scorecard_artifacts,
+)
 from war_room.settings import RuntimeEnvironment
+
+ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_discover_repo_root_from_nested_directory():
@@ -42,32 +61,310 @@ def test_bootstrap_runtime_creates_runtime_directories(tmp_path: Path):
 
 def test_bootstrap_verify_runs_supported_test_command(monkeypatch, capsys):
     commands: list[list[str]] = []
+    written_scorecards: list[tuple[str, str]] = []
+    written_preflight_artifacts: list[tuple[str, int, str]] = []
+    written_manifests: list[tuple[str, str]] = []
+    written_latest_pointers: list[tuple[str, str]] = []
 
-    def _fake_run(command: list[str], cwd: Path, check: bool) -> SimpleNamespace:
+    def _fake_run(
+        command: list[str],
+        cwd: Path,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> SimpleNamespace:
         commands.append(command)
         assert cwd == Path(__file__).resolve().parent.parent
+        assert capture_output is True
         assert check is False
-        return SimpleNamespace(returncode=0)
+        assert text is True
+        return SimpleNamespace(returncode=0, stdout=".....\n5 passed in 0.12s\n", stderr="")
+
+    def _fake_write_preflight(*_args, candidate: str, preflight_report, run_id: str, **_kwargs):
+        written_preflight_artifacts.append((candidate, preflight_report.scenario_count, run_id))
+        return Path("runs/preflight/test.json")
+
+    def _fake_write_scorecard(
+        *_args,
+        candidate: str,
+        run_id: str,
+        verification_summary: str,
+        preflight_report,
+        preflight_artifact_path,
+        **_kwargs,
+    ):
+        written_scorecards.append((candidate, verification_summary, preflight_report.scenario_count))
+        assert run_id == "20260418T120000Z"
+        assert preflight_artifact_path == Path("runs/preflight/test.json")
+        return (Path("runs/release_scorecards/test.json"), Path("runs/release_scorecards/test.md"))
+
+    def _fake_write_manifest(*_args, run_id: str, verification_summary: str, **_kwargs):
+        written_manifests.append((run_id, verification_summary))
+        return Path("runs/verify/test.json")
+
+    def _fake_write_latest(*_args, run_id: str, verify_manifest_path: Path, **_kwargs):
+        written_latest_pointers.append((run_id, str(verify_manifest_path)))
+        return Path("runs/verify/latest.json")
 
     monkeypatch.chdir(Path(__file__).resolve().parent.parent)
     monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("war_room.bootstrap._resolve_release_candidate", lambda *_args, **_kwargs: "codex/local")
+    monkeypatch.setattr("war_room.bootstrap._resolve_verify_run_id", lambda *_args, **_kwargs: "20260418T120000Z")
+    monkeypatch.setattr("war_room.bootstrap._write_verify_preflight_artifact", _fake_write_preflight)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_release_scorecard", _fake_write_scorecard)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_manifest", _fake_write_manifest)
+    monkeypatch.setattr("war_room.bootstrap._write_latest_verify_pointer", _fake_write_latest)
 
     exit_code = bootstrap_main(["--verify"])
 
     assert exit_code == 0
     assert commands == [[sys.executable, "-m", "pytest", "-q"]]
+    assert written_preflight_artifacts == [("codex/local", 4, "20260418T120000Z")]
+    assert written_scorecards == [("codex/local", "5 passed in 0.12s", 4)]
+    assert written_manifests == [("20260418T120000Z", "5 passed in 0.12s")]
+    assert written_latest_pointers == [("20260418T120000Z", str(Path("runs/verify/test.json")))]
     output = capsys.readouterr().out
     assert "CAT-Loss War Room Verification" in output
+    assert "## Verify Manifest" in output
+    assert f"Latest: {Path('runs/verify/latest.json')}" in output
+    assert "## Preflight Artifact" in output
+    assert "Run id: 20260418T120000Z" in output
+    assert "## Release Scorecard" in output
     assert "Verification passed." in output
 
 
 def test_bootstrap_verify_returns_nonzero_when_tests_fail(monkeypatch):
-    def _fake_run(command: list[str], cwd: Path, check: bool) -> SimpleNamespace:
-        return SimpleNamespace(returncode=3)
+    wrote_scorecard = False
+    wrote_preflight_artifact = False
+    wrote_manifest = False
+    wrote_latest_pointer = False
+
+    def _fake_run(
+        command: list[str],
+        cwd: Path,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(returncode=3, stdout="1 failed, 4 passed in 0.12s\n", stderr="")
+
+    def _fake_write_scorecard(*_args, **_kwargs):
+        nonlocal wrote_scorecard
+        wrote_scorecard = True
+        return (Path("runs/release_scorecards/test.json"), Path("runs/release_scorecards/test.md"))
+
+    def _fake_write_preflight(*_args, **_kwargs):
+        nonlocal wrote_preflight_artifact
+        wrote_preflight_artifact = True
+        return Path("runs/preflight/test.json")
+
+    def _fake_write_manifest(*_args, **_kwargs):
+        nonlocal wrote_manifest
+        wrote_manifest = True
+        return Path("runs/verify/test.json")
+
+    def _fake_write_latest(*_args, **_kwargs):
+        nonlocal wrote_latest_pointer
+        wrote_latest_pointer = True
+        return Path("runs/verify/latest.json")
 
     monkeypatch.chdir(Path(__file__).resolve().parent.parent)
     monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_preflight_artifact", _fake_write_preflight)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_release_scorecard", _fake_write_scorecard)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_manifest", _fake_write_manifest)
+    monkeypatch.setattr("war_room.bootstrap._write_latest_verify_pointer", _fake_write_latest)
 
     exit_code = bootstrap_main(["--verify"])
 
     assert exit_code == 3
+    assert wrote_scorecard is False
+    assert wrote_preflight_artifact is False
+    assert wrote_manifest is False
+    assert wrote_latest_pointer is False
+
+
+def test_bootstrap_verify_honors_release_candidate_override(monkeypatch):
+    written_scorecards: list[str] = []
+    written_manifests: list[str] = []
+    written_latest_pointers: list[str] = []
+
+    def _fake_run(
+        command: list[str],
+        cwd: Path,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(returncode=0, stdout="5 passed in 0.12s\n", stderr="")
+
+    def _fake_write_preflight(*_args, candidate: str, run_id: str, **_kwargs):
+        return Path(f"runs/preflight/{candidate}-{run_id}.json")
+
+    def _fake_write_scorecard(*_args, candidate: str, run_id: str, preflight_report, preflight_artifact_path, **_kwargs):
+        written_scorecards.append(f"{candidate}:{preflight_report.scenario_count}")
+        assert run_id == "20260418T120500Z"
+        assert preflight_artifact_path == Path("runs/preflight/manual-candidate-20260418T120500Z.json")
+        return (Path("runs/release_scorecards/test.json"), Path("runs/release_scorecards/test.md"))
+
+    def _fake_write_manifest(*_args, candidate: str, run_id: str, **_kwargs):
+        written_manifests.append(f"{candidate}:{run_id}")
+        return Path("runs/verify/test.json")
+
+    def _fake_write_latest(*_args, candidate: str, run_id: str, verify_manifest_path: Path, **_kwargs):
+        written_latest_pointers.append(f"{candidate}:{run_id}:{verify_manifest_path}")
+        return Path("runs/verify/latest.json")
+
+    monkeypatch.chdir(Path(__file__).resolve().parent.parent)
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr("war_room.bootstrap._resolve_verify_run_id", lambda *_args, **_kwargs: "20260418T120500Z")
+    monkeypatch.setattr("war_room.bootstrap._write_verify_preflight_artifact", _fake_write_preflight)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_release_scorecard", _fake_write_scorecard)
+    monkeypatch.setattr("war_room.bootstrap._write_verify_manifest", _fake_write_manifest)
+    monkeypatch.setattr("war_room.bootstrap._write_latest_verify_pointer", _fake_write_latest)
+
+    exit_code = bootstrap_main(["--verify", "--release-candidate", "manual-candidate"])
+
+    assert exit_code == 0
+    assert written_scorecards == ["manual-candidate:4"]
+    assert written_manifests == ["manual-candidate:20260418T120500Z"]
+    assert written_latest_pointers == [
+        f"manual-candidate:20260418T120500Z:{Path('runs/verify/test.json')}"
+    ]
+
+
+def test_write_latest_verify_pointer_persists_manifest_reference(tmp_path: Path):
+    runs_dir = tmp_path / "runs"
+    context = SimpleNamespace(settings=SimpleNamespace(runs_dir=runs_dir))
+
+    output_path = _write_latest_verify_pointer(
+        context,
+        run_id="20260418T163443Z",
+        created_at="2026-04-18T16:34:43.652387+00:00",
+        candidate="local-verify",
+        verify_manifest_path=Path("runs/verify/2026-04-18_local-verify_20260418t163443z.json"),
+    )
+
+    assert output_path == runs_dir / "verify" / "latest.json"
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload == {
+        "run_id": "20260418T163443Z",
+        "created_at": "2026-04-18T16:34:43.652387+00:00",
+        "candidate": "local-verify",
+        "verify_manifest_path": str(Path("runs/verify/2026-04-18_local-verify_20260418t163443z.json")),
+    }
+
+
+def test_write_verify_manifest_links_existing_artifacts_with_shared_run_id(tmp_path: Path):
+    context = bootstrap_runtime(start_path=ROOT, ensure_dirs=False)
+    preflight_report = run_demo_preflight(context)
+    run_id = preflight_run_id(preflight_report)
+    runs_dir = tmp_path / "runs"
+
+    preflight_artifact_path = write_preflight_artifact(
+        preflight_report,
+        output_dir=runs_dir / "preflight",
+        artifact_label="local-verify",
+        run_id=run_id,
+    )
+    fixture_coverage = collect_fixture_coverage(context.settings.cache_samples_dir)
+    scenario_registry = collect_scenario_registry_coverage(ROOT, context.settings.cache_samples_dir)
+    scorecard = build_demo_release_scorecard(
+        run_id=run_id,
+        candidate="local-verify",
+        verification_summary="5 passed in 0.12s",
+        artifact_date=preflight_report.created_at[:10],
+        preflight_artifact_path=str(preflight_artifact_path),
+        preflight_summary=summarize_preflight_report(preflight_report),
+        fixture_coverage=fixture_coverage,
+        scenario_registry=scenario_registry,
+    )
+    scorecard_json_path, scorecard_markdown_path = write_release_scorecard_artifacts(
+        scorecard,
+        output_dir=runs_dir / "release_scorecards",
+    )
+    verify_context = SimpleNamespace(repo_root=ROOT, settings=SimpleNamespace(runs_dir=runs_dir))
+
+    manifest_path = _write_verify_manifest(
+        verify_context,
+        run_id=run_id,
+        created_at=preflight_report.created_at,
+        candidate="local-verify",
+        verification_summary="5 passed in 0.12s",
+        preflight_artifact_path=preflight_artifact_path,
+        release_scorecard_json_path=scorecard_json_path,
+        release_scorecard_markdown_path=scorecard_markdown_path,
+    )
+
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    preflight_payload_path = Path(manifest_payload["preflight_artifact_path"])
+    scorecard_payload_path = Path(manifest_payload["release_scorecard_json_path"])
+    scorecard_markdown_payload_path = Path(manifest_payload["release_scorecard_markdown_path"])
+
+    assert preflight_payload_path.exists()
+    assert scorecard_payload_path.exists()
+    assert scorecard_markdown_payload_path.exists()
+
+    preflight_payload = json.loads(preflight_payload_path.read_text(encoding="utf-8"))
+    scorecard_payload = json.loads(scorecard_payload_path.read_text(encoding="utf-8"))
+
+    assert manifest_payload["run_id"] == run_id
+    assert preflight_payload["run_id"] == run_id
+    assert scorecard_payload["run_id"] == run_id
+    assert scorecard_payload["preflight_artifact_path"] == manifest_payload["preflight_artifact_path"]
+
+
+def test_resolve_release_candidate_uses_git_branch(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+
+    def _fake_run(
+        command: list[str],
+        cwd: Path,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> SimpleNamespace:
+        assert command == [
+            "git",
+            "-c",
+            f"safe.directory={repo_root}",
+            "rev-parse",
+            "--abbrev-ref",
+            "HEAD",
+        ]
+        assert cwd == repo_root
+        return SimpleNamespace(returncode=0, stdout="codex/demo-verify\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    candidate = _resolve_release_candidate(SimpleNamespace(repo_root=repo_root))
+
+    assert candidate == "codex/demo-verify"
+
+
+def test_resolve_release_candidate_falls_back_when_branch_is_unavailable(monkeypatch):
+    repo_root = Path(__file__).resolve().parent.parent
+
+    def _fake_run(
+        command: list[str],
+        cwd: Path,
+        capture_output: bool,
+        check: bool,
+        text: bool,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(returncode=0, stdout="HEAD\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    candidate = _resolve_release_candidate(SimpleNamespace(repo_root=repo_root))
+
+    assert candidate == "local-verify"
+
+
+def test_extract_pytest_summary_returns_final_result_line():
+    summary = _extract_pytest_summary(
+        "tests/test_bootstrap.py .....                                     [100%]\n5 passed in 0.12s\n",
+        "",
+    )
+
+    assert summary == "5 passed in 0.12s"

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -6,7 +6,12 @@ import json
 from pathlib import Path
 
 from war_room.bootstrap import bootstrap_runtime, main as bootstrap_main
-from war_room.preflight import render_demo_preflight_report, run_demo_preflight
+from war_room.preflight import (
+    preflight_run_id,
+    render_demo_preflight_report,
+    run_demo_preflight,
+    write_preflight_artifact,
+)
 from war_room.query_plan import build_research_plan, load_case_intake
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -94,6 +99,26 @@ def test_bootstrap_cli_preflight_json_output(monkeypatch, capsys):
     assert payload["scenarios"][0]["issue_count"] > 0
     assert payload["scenarios"][0]["memo_section_count"] > 0
     assert payload["scenarios"][0]["export_artifact_count"] == 1
+
+
+def test_write_preflight_artifact_writes_json_payload(tmp_path: Path):
+    context = bootstrap_runtime(start_path=ROOT, ensure_dirs=False)
+    report = run_demo_preflight(context)
+    run_id = preflight_run_id(report)
+
+    output_path = write_preflight_artifact(
+        report,
+        output_dir=tmp_path / "preflight",
+        artifact_label="local-verify",
+        run_id=run_id,
+    )
+
+    assert output_path.exists()
+    assert output_path.name == f"2026-04-18_local-verify_{run_id.lower()}.json"
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["run_id"] == run_id
+    assert payload["passed"] is True
+    assert payload["scenario_count"] == len(_expected_scenario_keys())
 
 
 def test_demo_preflight_reuses_one_shared_query_plan(monkeypatch):

--- a/tests/test_release_scorecard.py
+++ b/tests/test_release_scorecard.py
@@ -2,14 +2,18 @@
 
 from pathlib import Path
 
+from war_room.bootstrap import bootstrap_runtime
+from war_room.preflight import DemoPreflightReport, PreflightCheck, PreflightScenarioReport, run_demo_preflight
 from war_room.release_scorecard import (
     DEFAULT_VERIFICATION_COMMAND,
     build_demo_release_scorecard,
     collect_fixture_coverage,
     collect_scenario_registry_coverage,
     render_release_scorecard_markdown,
+    summarize_preflight_report,
     write_release_scorecard_artifacts,
 )
+from war_room.scenarios import ScenarioAvailabilitySummary
 
 ROOT = Path(__file__).resolve().parent.parent
 CACHE_SAMPLES_DIR = ROOT / "cache_samples"
@@ -73,10 +77,16 @@ def test_default_verification_command_matches_supported_path():
 def test_build_demo_release_scorecard_uses_fixture_calibration():
     summary = collect_fixture_coverage(CACHE_SAMPLES_DIR)
     registry = collect_scenario_registry_coverage(ROOT, CACHE_SAMPLES_DIR)
+    preflight_summary = summarize_preflight_report(
+        run_demo_preflight(bootstrap_runtime(start_path=ROOT, ensure_dirs=False))
+    )
     scorecard = build_demo_release_scorecard(
+        run_id="20260311T101530Z",
         candidate="codex/local",
         verification_summary="179 passed",
         artifact_date="2026-03-11",
+        preflight_artifact_path="runs/preflight/2026-03-11_codex-local_20260311t101530z.json",
+        preflight_summary=preflight_summary,
         fixture_coverage=summary,
         scenario_registry=registry,
     )
@@ -91,7 +101,13 @@ def test_build_demo_release_scorecard_uses_fixture_calibration():
     assert scorecard.dimensions[1].name == "Evidence Quality"
     assert scorecard.dimensions[1].score == 2
     assert scorecard.must_pass_gates[0].evidence == f"{DEFAULT_VERIFICATION_COMMAND} -> 179 passed"
+    assert scorecard.must_pass_gates[1].passed is True
     assert scorecard.must_pass_gates[2].passed is True
+    assert scorecard.run_id == "20260311T101530Z"
+    assert scorecard.preflight_summary is not None
+    assert scorecard.preflight_artifact_path == "runs/preflight/2026-03-11_codex-local_20260311t101530z.json"
+    assert scorecard.preflight_summary.passed is True
+    assert scorecard.preflight_summary.scenario_count == len(_expected_scenario_keys())
     assert scorecard.fixture_coverage is not None
     assert scorecard.fixture_coverage.scenario_count == len(_expected_scenario_keys())
     assert scorecard.scenario_registry is not None
@@ -102,7 +118,10 @@ def test_build_demo_release_scorecard_uses_fixture_calibration():
 
     markdown = render_release_scorecard_markdown(scorecard)
     assert "# Release Scorecard" in markdown
+    assert "Run id: 20260311T101530Z" in markdown
     assert "codex/local" in markdown
+    assert "Preflight artifact: runs/preflight/2026-03-11_codex-local_20260311t101530z.json" in markdown
+    assert "## Offline Preflight" in markdown
     assert "## Fixture Coverage" in markdown
     assert "## Scenario Registry" in markdown
     assert "## Threshold Calibration" in markdown
@@ -114,6 +133,7 @@ def test_write_release_scorecard_artifacts_writes_json_and_markdown(tmp_path: Pa
     summary = collect_fixture_coverage(CACHE_SAMPLES_DIR)
     registry = collect_scenario_registry_coverage(ROOT, CACHE_SAMPLES_DIR)
     scorecard = build_demo_release_scorecard(
+        run_id="20260311T101530Z",
         candidate="Feature Branch 27",
         verification_summary="179 passed",
         artifact_date="2026-03-11",
@@ -128,8 +148,8 @@ def test_write_release_scorecard_artifacts_writes_json_and_markdown(tmp_path: Pa
 
     assert json_path.exists()
     assert markdown_path.exists()
-    assert json_path.name == "2026-03-11_feature-branch-27.json"
-    assert markdown_path.name == "2026-03-11_feature-branch-27.md"
+    assert json_path.name == "2026-03-11_feature-branch-27_20260311t101530z.json"
+    assert markdown_path.name == "2026-03-11_feature-branch-27_20260311t101530z.md"
 
     markdown = markdown_path.read_text(encoding="utf-8")
     assert "CI release-evidence automation is still pending." in markdown
@@ -139,8 +159,10 @@ def test_write_release_scorecard_artifacts_writes_json_and_markdown(tmp_path: Pa
     assert "Threshold Calibration" in markdown
 
     payload = json_path.read_text(encoding="utf-8")
+    assert '"run_id": "20260311T101530Z"' in payload
     assert '"candidate": "Feature Branch 27"' in payload
     assert '"target_release_level": "Demo-ready"' in payload
+    assert '"preflight_artifact_path": null' in payload
     assert '"fixture_coverage"' in payload
     assert '"scenario_registry"' in payload
     assert '"calibration_thresholds"' in payload
@@ -150,6 +172,7 @@ def test_build_demo_release_scorecard_marks_failed_verification_gate():
     summary = collect_fixture_coverage(CACHE_SAMPLES_DIR)
     registry = collect_scenario_registry_coverage(ROOT, CACHE_SAMPLES_DIR)
     scorecard = build_demo_release_scorecard(
+        run_id="20260418T120000Z",
         candidate="codex/local",
         verification_summary="1 failed, 178 passed",
         artifact_date="2026-03-18",
@@ -159,3 +182,86 @@ def test_build_demo_release_scorecard_marks_failed_verification_gate():
 
     assert scorecard.dimensions[0].score == 0
     assert scorecard.must_pass_gates[0].passed is False
+
+
+def test_summarize_preflight_report_captures_failed_scenarios():
+    report = DemoPreflightReport(
+        created_at="2026-04-18T12:00:00+00:00",
+        repo_root=str(ROOT),
+        cache_samples_dir=str(CACHE_SAMPLES_DIR),
+        scenario_count=1,
+        scenarios=[
+            PreflightScenarioReport(
+                case_key="broken_case",
+                intake_path="eval/intakes/broken_case.json",
+                availability=ScenarioAvailabilitySummary(
+                    surface="preflight",
+                    scenario_id="broken_case",
+                    title="Broken Case",
+                    case_key="broken_case",
+                    status="offline-ready",
+                    detail="Synthetic test fixture.",
+                ),
+                checks=[
+                    PreflightCheck(name="intake payload loads", passed=True, evidence="ok"),
+                    PreflightCheck(name="memo includes disclaimer language", passed=False, evidence="missing"),
+                ],
+                workflow_status="failed",
+                workflow_review_required=True,
+            )
+        ],
+    )
+
+    summary = summarize_preflight_report(report)
+
+    assert summary.passed is False
+    assert summary.scenario_count == 1
+    assert summary.passed_scenario_count == 0
+    assert summary.scenario_keys == ["broken_case"]
+    assert summary.scenarios[0].failed_checks == ["memo includes disclaimer language"]
+
+
+def test_build_demo_release_scorecard_marks_failed_preflight_gate():
+    summary = collect_fixture_coverage(CACHE_SAMPLES_DIR)
+    registry = collect_scenario_registry_coverage(ROOT, CACHE_SAMPLES_DIR)
+    preflight_summary = summarize_preflight_report(
+        DemoPreflightReport(
+            created_at="2026-04-18T12:00:00+00:00",
+            repo_root=str(ROOT),
+            cache_samples_dir=str(CACHE_SAMPLES_DIR),
+            scenario_count=1,
+            scenarios=[
+                PreflightScenarioReport(
+                    case_key="broken_case",
+                    intake_path="eval/intakes/broken_case.json",
+                    availability=ScenarioAvailabilitySummary(
+                        surface="preflight",
+                        scenario_id="broken_case",
+                        title="Broken Case",
+                        case_key="broken_case",
+                        status="offline-ready",
+                        detail="Synthetic test fixture.",
+                    ),
+                    checks=[
+                        PreflightCheck(name="offline smoke execution", passed=False, evidence="RuntimeError: boom"),
+                    ],
+                    workflow_status="failed",
+                    workflow_review_required=True,
+                )
+            ],
+        )
+    )
+    scorecard = build_demo_release_scorecard(
+        run_id="20260418T120000Z",
+        candidate="codex/local",
+        verification_summary="179 passed",
+        artifact_date="2026-04-18",
+        preflight_summary=preflight_summary,
+        fixture_coverage=summary,
+        scenario_registry=registry,
+    )
+
+    assert scorecard.dimensions[0].score == 1
+    assert scorecard.dimensions[0].verdict == "Weak"
+    assert scorecard.must_pass_gates[1].passed is False
+    assert "0/1 scenarios passed" in scorecard.must_pass_gates[1].evidence


### PR DESCRIPTION
## Summary
- make \\python -m war_room --verify\\ emit a complete, linked, run-scoped release-evidence bundle
- add live preflight artifacts, verify manifests, and a stable \\uns/verify/latest.json\\ discovery pointer
- add an end-to-end artifact consistency guard that reloads the verify manifest and validates the linked bundle

## Why
- #27 already had a rubric and scorecard path, but the supported local verification flow did not yet produce a complete auditable evidence bundle on its own
- this packages the local release-evidence workflow into one supported command without broadening scope into larger CI or runtime redesign

## Validation
- \\$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q\\ -> \\24 passed\\`n- \\$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify\\ -> passed, \\277 passed\\`n