### PR TITLE
[codex] sync post-merge status docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,11 +12,11 @@ This repo exists to support demo-ready legal research acceleration for Merlin La
 2. [`docs/HANDOFF.md`](./docs/HANDOFF.md) for current implemented-vs-planned status.
 3. [`docs/repo-brief.md`](./docs/repo-brief.md) for the short operating brief.
 4. [`docs/heartbeat.md`](./docs/heartbeat.md) for the current branch, focus, and next best task.
-5. [`logs/2026-03-27-session.md`](./logs/2026-03-27-session.md) for the latest memory-stack session note.
+5. [`docs/SESSION_LOG.md`](./docs/SESSION_LOG.md) for the latest build-session memory and validation trail.
 
 ## Current milestone
 
-Keep the V0 notebook demo stable while operationalizing issue `#27` and completing the remaining `#6` to `#9` foundation slices. The active runtime is still the notebook plus `src/war_room/`; `apps/`, `workers/`, and `packages/` remain future-boundary placeholders.
+Keep the V0 notebook demo stable while finishing the remaining operationalization in issue `#27` and completing the remaining `#6` to `#9` foundation slices. The active runtime is still the notebook plus `src/war_room/`; `apps/`, `workers/`, and `packages/` remain future-boundary placeholders.
 
 ## Non-goals
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Only the Milton benchmark currently has committed offline cache fixtures, so cac
 
 ## Current Status
 
-**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `252` tests are passing under the supported bootstrap path, and CI now enforces:
+**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `277` tests are passing under the supported bootstrap path, the supported `--verify` flow now writes a linked run-scoped release-evidence bundle, and CI now enforces:
 - Fresh environment install + full test run
 - Editable package bootstrap validation
 - Offline fixture smoke validation across committed scenarios
@@ -123,7 +123,7 @@ Only the Milton benchmark currently has committed offline cache fixtures, so cac
 
 **Specified, not built yet:** `docs/V2_WORKFLOW_IA.md`, `docs/V2_EVIDENCE_SCHEMA.md`, and `docs/V2_RELEASE_RUBRIC.md` are the written source-of-truth specs for the current V2 planning layer, while `apps/`, `workers/`, and `packages/` remain placeholder boundaries for later implementation.
 
-Issues `#4`, `#5`, `#22`, `#23`, and `#24` are complete and closed. The written source-of-truth specs for `#23` and `#24` live in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard in `docs/V2_RELEASE_RUBRIC.md` and remains open for CI and pilot operationalization, issue `#6` is underway with slices 1-7 landed, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
+Issues `#4`, `#5`, `#22`, `#23`, and `#24` are complete and closed. The written source-of-truth specs for `#23` and `#24` live in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard, CI artifact emission plus validation, and a linked local verify-evidence workflow in `docs/V2_RELEASE_RUBRIC.md`, and remains open for broader CI/pilot operationalization. Issue `#6` is underway with slices 1-7 landed, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
 
 ## Roadmap (Simple)
 
@@ -150,3 +150,4 @@ This tool is a research accelerator, not a legal oracle. All outputs carry:
 - "DRAFT - ATTORNEY WORK PRODUCT" watermarks on exports
 
 No output should be used without independent verification by a licensed attorney.
+

--- a/docs/BUILD_CHECKLIST.md
+++ b/docs/BUILD_CHECKLIST.md
@@ -4,7 +4,7 @@ Simple execution checklist aligned with the live GitHub roadmap.
 
 ## Completed
 
-- [x] Exa compatibility hardening shipped ([#4](https://github.com/itprodirect/cat-loss-war-room-demo/issues/4))
+- [x] Exa compatibility hardening shipped ([#4](https://github.com/itprodirect/cat-loss-war-room/issues/4))
 - [x] Dependency baseline pinned and reproducible
 - [x] CI fresh-env gate live
 - [x] exa-py compatibility matrix live
@@ -14,33 +14,34 @@ Simple execution checklist aligned with the live GitHub roadmap.
 
 ## V2 Written Specs
 
-- [x] [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) product foundation and repo shape
-- [x] [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) workflow IA and design system source of truth
-- [x] [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) canonical evidence graph and audit schema source of truth
-- [ ] [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) quality rubric and release scorecard (v0.1 rubric doc, local artifact generator, fixture-calibrated scenario coverage, explicit demo-ready thresholds, CI artifact emission plus validation, and `python -m war_room --verify` scorecard emission with live preflight evidence plus linked run-scoped preflight artifacts, verify manifests, a stable `runs/verify/latest.json` pointer, and an end-to-end artifact consistency guard landed; pilot operationalization still needed)
+- [x] [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) product foundation and repo shape
+- [x] [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) workflow IA and design system source of truth
+- [x] [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) canonical evidence graph and audit schema source of truth
+- [ ] [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) quality rubric and release scorecard (v0.1 rubric doc, local artifact generator, fixture-calibrated scenario coverage, explicit demo-ready thresholds, CI artifact emission plus validation, and `python -m war_room --verify` scorecard emission with live preflight evidence plus linked run-scoped preflight artifacts, verify manifests, a stable `runs/verify/latest.json` pointer, and an end-to-end artifact consistency guard landed; pilot operationalization still needed)
 
 ## Immediate Execution Priorities
 
-- [x] [#5](https://github.com/itprodirect/cat-loss-war-room-demo/issues/5) intake schema alignment
-- [ ] [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) typed domain models (slices 1-7 complete: intake/query + module packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts)
-- [ ] [#7](https://github.com/itprodirect/cat-loss-war-room-demo/issues/7) retrieval contracts (provider seam + notebook retrieval-state + citation-verify + deterministic retrieval-task timing slices landed)
-- [ ] [#8](https://github.com/itprodirect/cat-loss-war-room-demo/issues/8) scenario fixtures + snapshots (four committed scenario directories now cover Florida, Texas, and Louisiana; broader breadth and snapshot thresholds still needed)
-- [ ] [#9](https://github.com/itprodirect/cat-loss-war-room-demo/issues/9) expanded CI gates (offline fixture smoke gate and release-scorecard artifact emission plus validation landed; broader CI layering still needed)
+- [x] [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) intake schema alignment
+- [ ] [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) typed domain models (slices 1-7 complete: intake/query + module packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts)
+- [ ] [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) retrieval contracts (provider seam + notebook retrieval-state + citation-verify + deterministic retrieval-task timing slices landed)
+- [ ] [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) scenario fixtures + snapshots (four committed scenario directories now cover Florida, Texas, and Louisiana; broader breadth and snapshot thresholds still needed)
+- [ ] [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) expanded CI gates (offline fixture smoke gate, release-scorecard artifact emission plus validation, and the supported local verify-evidence workflow landed; broader CI layering still needed)
 
 ## Product Core (queued)
 
-- [ ] [#10](https://github.com/itprodirect/cat-loss-war-room-demo/issues/10) API orchestrator
-- [ ] [#11](https://github.com/itprodirect/cat-loss-war-room-demo/issues/11) guided UX
-- [ ] [#12](https://github.com/itprodirect/cat-loss-war-room-demo/issues/12) evidence normalization
-- [ ] [#13](https://github.com/itprodirect/cat-loss-war-room-demo/issues/13) caselaw quality v2
+- [ ] [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) API orchestrator
+- [ ] [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) guided UX
+- [ ] [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) evidence normalization
+- [ ] [#13](https://github.com/itprodirect/cat-loss-war-room/issues/13) caselaw quality v2
 
 ## Trust and Adoption (queued)
 
-- [ ] [#14](https://github.com/itprodirect/cat-loss-war-room-demo/issues/14) citation verification hardening
-- [ ] [#15](https://github.com/itprodirect/cat-loss-war-room-demo/issues/15) memo workspace v2
-- [ ] [#16](https://github.com/itprodirect/cat-loss-war-room-demo/issues/16) firm memory v1
-- [ ] [#17](https://github.com/itprodirect/cat-loss-war-room-demo/issues/17) observability and cost controls
-- [ ] [#18](https://github.com/itprodirect/cat-loss-war-room-demo/issues/18) security baseline
-- [ ] [#19](https://github.com/itprodirect/cat-loss-war-room-demo/issues/19) pilot validation
-- [ ] [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) AI guardrails and eval harness
-- [ ] [#26](https://github.com/itprodirect/cat-loss-war-room-demo/issues/26) human review workflow
+- [ ] [#14](https://github.com/itprodirect/cat-loss-war-room/issues/14) citation verification hardening
+- [ ] [#15](https://github.com/itprodirect/cat-loss-war-room/issues/15) memo workspace v2
+- [ ] [#16](https://github.com/itprodirect/cat-loss-war-room/issues/16) firm memory v1
+- [ ] [#17](https://github.com/itprodirect/cat-loss-war-room/issues/17) observability and cost controls
+- [ ] [#18](https://github.com/itprodirect/cat-loss-war-room/issues/18) security baseline
+- [ ] [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) pilot validation
+- [ ] [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) AI guardrails and eval harness
+- [ ] [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) human review workflow
+

--- a/docs/DECISION_LOG.md
+++ b/docs/DECISION_LOG.md
@@ -95,5 +95,5 @@ Track key architecture and design decisions so future sessions (human or AI) und
 ## D018: Release scorecards derive fixture coverage from committed scenarios
 **Date:** 2026-03-11
 **Decision:** Treat committed scenario folders under `cache_samples/` as the source of truth for local release-scorecard fixture coverage reporting.
-**Reason:** The repo now has three public/redacted offline scenarios across Florida, Texas, and Louisiana. Scorecard artifacts should report real committed coverage instead of a hardcoded narrative so `#27` calibration stays aligned with `#8` fixture work and `#9` CI smoke evidence.
+**Reason:** The repo now has four public/redacted offline scenarios across Florida, Texas, and Louisiana. Scorecard artifacts should report real committed coverage instead of a hardcoded narrative so `#27` calibration stays aligned with `#8` fixture work and `#9` CI smoke evidence.
 **Impact:** When fixture scenarios are added, removed, or materially changed, the release scorecard should reflect that automatically and the canonical docs should be updated with the new coverage and supported test count.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -15,13 +15,13 @@ Given a case intake, it assembles:
 
 This is research acceleration, not legal advice.
 
-## 2) Current status (as of March 30, 2026)
+## 2) Current status (as of April 18, 2026)
 
 | Item | Status |
 |---|---|
 | Notebook cells 0-7 | Working |
 | Offline demo (`USE_CACHE=true`) | Working |
-| Tests | 268 passing under editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
+| Tests | 277 passing under the supported verify path after editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
 | CI | Fresh-env test gate + offline fixture smoke gate + exa-py compatibility matrix + release-scorecard artifact job with artifact validation, all using editable package install |
 | Exa compatibility hardening (`#4`) | Complete and closed |
 | Intake schema alignment (`#5`) | Complete and closed |
@@ -30,7 +30,7 @@ This is research acceleration, not legal advice.
 | Product foundation (`#22`) | Complete and closed: packaging/bootstrap lane implemented |
 | Workflow IA spec (`#23`) | Complete and closed as the written source of truth in `docs/V2_WORKFLOW_IA.md` |
 | Evidence schema spec (`#24`) | Complete and closed as the written source of truth in `docs/V2_EVIDENCE_SCHEMA.md` |
-| Quality rubric (`#27`) | First-pass rubric plus local artifact workflow landed in `docs/V2_RELEASE_RUBRIC.md`; demo-ready threshold calibration is now explicit in the scorecard, while CI and pilot operationalization remain open |
+| Quality rubric (`#27`) | First-pass rubric plus local and CI artifact workflows landed in `docs/V2_RELEASE_RUBRIC.md`; demo-ready threshold calibration, live preflight evidence, run-scoped verify artifacts, verify manifests, and a stable latest pointer are now explicit, while broader CI and pilot operationalization remain open |
 | Cache samples | Milton/Citizens/Pinellas + TX hail/Allstate/Tarrant + TX hail matching/Allstate Texas Lloyds/Tarrant DP-3 + Ida/Lloyd's/Orleans committed |
 
 ## 3) What changed recently
@@ -54,6 +54,7 @@ This is research acceleration, not legal advice.
 - CI now includes an explicit offline fixture smoke job, and the local release scorecard records fixture coverage from the committed scenario set.
 - The repository now has a deterministic offline demo preflight command at `python -m war_room --preflight`.
 - The repository now also has a one-command local verification wrapper at `python -m war_room --verify`.
+- The supported verify flow now emits a linked release-evidence bundle: run-scoped preflight artifacts, run-scoped scorecards, verify manifests, a stable `runs/verify/latest.json` pointer, and an integrity test that reloads the linked artifact set.
 - The notebook and preflight surfaces now expose a workflow-oriented research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run timeline, so grouped support, issue-level review, section readiness, export posture, and review-required state are visible before the memo is treated as complete.
 - The Milton benchmark fixture lane now normalizes cached citation trust metadata, carrier/case-law runtime quality, and markdown/export readability without changing the scenario registry or overall notebook-era runtime flow.
 
@@ -82,13 +83,13 @@ Core implementation lives in `src/war_room/`.
 
 - Notebook UX is useful for demos but not ideal for non-technical users.
 - Case law relevance and authority summarization still need stricter filtering/ranking in edge cases.
-- Three public/redacted fact patterns are pre-seeded in cache samples, but broader scenario coverage and thresholds are still needed.
-- Export output quality is materially cleaner in the Milton benchmark lane, but it is not yet polished for repeated client-facing use across broader fixture coverage.
+- Four public/redacted fact patterns are pre-seeded in cache samples, but broader scenario coverage and thresholds are still needed.
+- Export output quality is materially cleaner than earlier notebook-era baselines, but it is not yet polished for repeated client-facing use across broader fixture coverage.
 
 ## 7) Roadmap summary
 
 ### Now
-- #27 quality rubric and release scorecard calibration
+- #27 broader CI and pilot operationalization of the release scorecard
 - #6 typed domain contracts
 - #7 retrieval provider abstraction and contracts (provider seam, notebook retrieval-state, and citation-verify slices landed)
 - #8 multi-jurisdiction fixtures and snapshots

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,57 +1,57 @@
 # Roadmap (Simple, Current)
 
-Last updated: March 18, 2026
+Last updated: April 18, 2026
 
 This is the short version. Clean, practical, no drama.
 
 ## Where we are now
 
 - Demo pipeline is stable.
-- 252 tests are passing.
+- 277 tests are passing on the supported verify path.
 - CI has a fresh-environment gate, editable-package install, an explicit offline fixture smoke job, and the `exa-py` compatibility matrix.
 - CI now also emits and validates a release-scorecard artifact from the calibrated `#27` workflow.
 - The supported test path is editable install plus `pytest -q`, or `PYTHONPATH=src` for ad hoc local runs. Raw-checkout `pytest -q` is not supported.
 - The offline demo path now has a deterministic preflight command: `python -m war_room --preflight`.
 - The notebook and preflight surfaces now expose a first workflow layer with research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline review state.
 - A deeper V2 foundation layer is tracked in issues `#22` through `#27`.
-- Issue [#4](https://github.com/itprodirect/cat-loss-war-room-demo/issues/4) is complete and closed.
-- Issue [#5](https://github.com/itprodirect/cat-loss-war-room-demo/issues/5) is complete and closed.
-- Issue [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) is complete and closed.
-- Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are complete and closed as written source-of-truth specs.
-- Issue [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) is still open, but the local scorecard now includes explicit demo-ready threshold calibration in `docs/V2_RELEASE_RUBRIC.md`.
-- Issue [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) is in progress (slices 1-7 landed locally; review/export graph-linkage contract slice now added).
+- Issue [#4](https://github.com/itprodirect/cat-loss-war-room/issues/4) is complete and closed.
+- Issue [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) is complete and closed.
+- Issue [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) is complete and closed.
+- Issues [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) are complete and closed as written source-of-truth specs.
+- Issue [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) is still open, but the local and CI release-evidence path now includes explicit demo-ready threshold calibration, run-scoped artifacts, verify manifests, and a stable latest pointer in `docs/V2_RELEASE_RUBRIC.md`.
+- Issue [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) is in progress (slices 1-7 landed locally; review/export graph-linkage contract slice now added).
 - Placeholder directories under `apps/`, `packages/`, and `workers/` are planned V2 boundaries only. The active runtime remains the notebook plus `src/war_room/`.
 
 ## Delivery layers
 
 - V0 implemented now: notebook-first demo, cache-backed offline lane, package bootstrap, and current memo pipeline.
 - V2 definition work completed: workflow/IA in `#23`, evidence schema in `#24`, repo/runtime boundary framing in `#22`, and a first-pass release rubric in `#27`.
-- V2 implementation work still pending: refine and operationalize the release rubric from `#27`, complete remaining foundation work in `#6` to `#9`, then build product surfaces in `#10` onward.
+- V2 implementation work still pending: broaden CI and pilot operationalization from `#27`, complete remaining foundation work in `#6` to `#9`, then build product surfaces in `#10` onward.
 
 ## Active Priority Rank
 
 This is the current best-to-worst order for active work on the current build.
-Issue [#3](https://github.com/itprodirect/cat-loss-war-room-demo/issues/3) remains the umbrella epic and is not ranked with execution tickets.
+Issue [#3](https://github.com/itprodirect/cat-loss-war-room/issues/3) remains the umbrella epic and is not ranked with execution tickets.
 
-Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) are not ranked here because their written source-of-truth docs already landed and those definition issues are closed. Their downstream implementation work lives in `#10`, `#11`, and `#12`.
+Issues [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) are not ranked here because their written source-of-truth docs already landed and those definition issues are closed. Their downstream implementation work lives in `#10`, `#11`, and `#12`.
 
-1. [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) Refine and operationalize the first-pass quality rubric and release scorecard
-2. [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) Complete remaining typed domain contracts
-3. [#7](https://github.com/itprodirect/cat-loss-war-room-demo/issues/7) Retrieval provider abstraction + contract tests (four slices landed)
-4. [#8](https://github.com/itprodirect/cat-loss-war-room-demo/issues/8) Multi-jurisdiction fixture suite + snapshots
-5. [#9](https://github.com/itprodirect/cat-loss-war-room-demo/issues/9) Expand CI quality gates
-6. [#10](https://github.com/itprodirect/cat-loss-war-room-demo/issues/10) API orchestrator with graceful degradation
-7. [#11](https://github.com/itprodirect/cat-loss-war-room-demo/issues/11) Guided web intake + run-status UX
-8. [#12](https://github.com/itprodirect/cat-loss-war-room-demo/issues/12) Evidence normalization + provenance implementation
-9. [#13](https://github.com/itprodirect/cat-loss-war-room-demo/issues/13) Caselaw quality v2
-10. [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) AI guardrails + eval harness
-11. [#26](https://github.com/itprodirect/cat-loss-war-room-demo/issues/26) Human review workflow
-12. [#14](https://github.com/itprodirect/cat-loss-war-room-demo/issues/14) Citation verification hardening
-13. [#15](https://github.com/itprodirect/cat-loss-war-room-demo/issues/15) Memo workspace v2
-14. [#17](https://github.com/itprodirect/cat-loss-war-room-demo/issues/17) Observability + cost controls
-15. [#18](https://github.com/itprodirect/cat-loss-war-room-demo/issues/18) Security baseline
-16. [#19](https://github.com/itprodirect/cat-loss-war-room-demo/issues/19) Attorney pilot validation
-17. [#16](https://github.com/itprodirect/cat-loss-war-room-demo/issues/16) Firm memory v1
+1. [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) Broaden CI and pilot operationalization of the calibrated release rubric
+2. [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) Complete remaining typed domain contracts
+3. [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) Expand CI quality gates beyond the lanes already in place
+4. [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) Retrieval provider abstraction + contract tests (four slices landed)
+5. [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) Multi-jurisdiction fixture suite + snapshots
+6. [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) API orchestrator with graceful degradation
+7. [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) Guided web intake + run-status UX
+8. [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) Evidence normalization + provenance implementation
+9. [#13](https://github.com/itprodirect/cat-loss-war-room/issues/13) Caselaw quality v2
+10. [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) AI guardrails + eval harness
+11. [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) Human review workflow
+12. [#14](https://github.com/itprodirect/cat-loss-war-room/issues/14) Citation verification hardening
+13. [#15](https://github.com/itprodirect/cat-loss-war-room/issues/15) Memo workspace v2
+14. [#17](https://github.com/itprodirect/cat-loss-war-room/issues/17) Observability + cost controls
+15. [#18](https://github.com/itprodirect/cat-loss-war-room/issues/18) Security baseline
+16. [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) Attorney pilot validation
+17. [#16](https://github.com/itprodirect/cat-loss-war-room/issues/16) Firm memory v1
 
 ## Triage Notes
 
@@ -63,39 +63,39 @@ Issues [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) an
   - `#11` should explicitly implement the workflow defined in `#23`.
   - `#12` should explicitly implement against the canonical schema defined in `#24`.
 - `#27` should now focus on CI and pilot operationalization of the calibrated rubric rather than inventing the first rubric draft.
-  - CI artifact emission already landed; the remaining work is broader gate coverage and pilot evidence.
+  - CI artifact emission, local verify evidence bundles, and artifact integrity checks already landed; the remaining work is broader gate coverage and pilot evidence.
 
 ## Now (next 2-3 weeks)
 
 Goal: finish the remaining definition/foundation work so V2 implementation starts from stable contracts and quality gates.
 
-- [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) Refine and operationalize the first-pass quality rubric and release scorecard
-- [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) Complete remaining typed domain contracts
-- [#7](https://github.com/itprodirect/cat-loss-war-room-demo/issues/7) Retrieval provider abstraction + contract tests (provider seam + notebook retrieval-state + citation-verify + deterministic timing slices landed)
-- [#8](https://github.com/itprodirect/cat-loss-war-room-demo/issues/8) Multi-jurisdiction fixture suite + snapshots
-- [#9](https://github.com/itprodirect/cat-loss-war-room-demo/issues/9) Expand CI quality gates
+- [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) Broaden CI and pilot operationalization of the calibrated release scorecard
+- [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) Complete remaining typed domain contracts
+- [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) Retrieval provider abstraction + contract tests (provider seam + notebook retrieval-state + citation-verify + deterministic timing slices landed)
+- [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) Multi-jurisdiction fixture suite + snapshots
+- [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) Expand CI quality gates
 
 ## Next (30-60 days)
 
 Goal: build the first true product workflow around the research engine.
 
-- [#10](https://github.com/itprodirect/cat-loss-war-room-demo/issues/10) API orchestrator with graceful degradation
-- [#11](https://github.com/itprodirect/cat-loss-war-room-demo/issues/11) Guided web intake + run status UX
-- [#12](https://github.com/itprodirect/cat-loss-war-room-demo/issues/12) Evidence normalization + provenance
-- [#13](https://github.com/itprodirect/cat-loss-war-room-demo/issues/13) Caselaw quality v2
-- [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) AI guardrails + eval harness
-- [#26](https://github.com/itprodirect/cat-loss-war-room-demo/issues/26) Human review workflow
+- [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) API orchestrator with graceful degradation
+- [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) Guided web intake + run status UX
+- [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) Evidence normalization + provenance
+- [#13](https://github.com/itprodirect/cat-loss-war-room/issues/13) Caselaw quality v2
+- [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) AI guardrails + eval harness
+- [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) Human review workflow
 
 ## Then (60-90 days)
 
 Goal: trust, polish, and real-world adoption readiness.
 
-- [#14](https://github.com/itprodirect/cat-loss-war-room-demo/issues/14) Citation verification hardening
-- [#15](https://github.com/itprodirect/cat-loss-war-room-demo/issues/15) Memo workspace v2
-- [#16](https://github.com/itprodirect/cat-loss-war-room-demo/issues/16) Firm memory v1
-- [#17](https://github.com/itprodirect/cat-loss-war-room-demo/issues/17) Observability + cost controls
-- [#18](https://github.com/itprodirect/cat-loss-war-room-demo/issues/18) Security baseline
-- [#19](https://github.com/itprodirect/cat-loss-war-room-demo/issues/19) Attorney pilot validation
+- [#14](https://github.com/itprodirect/cat-loss-war-room/issues/14) Citation verification hardening
+- [#15](https://github.com/itprodirect/cat-loss-war-room/issues/15) Memo workspace v2
+- [#16](https://github.com/itprodirect/cat-loss-war-room/issues/16) Firm memory v1
+- [#17](https://github.com/itprodirect/cat-loss-war-room/issues/17) Observability + cost controls
+- [#18](https://github.com/itprodirect/cat-loss-war-room/issues/18) Security baseline
+- [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) Attorney pilot validation
 
 ## Success checks we care about
 
@@ -116,3 +116,4 @@ Goal: trust, polish, and real-world adoption readiness.
 - Release rubric source of truth: [V2_RELEASE_RUBRIC.md](V2_RELEASE_RUBRIC.md)
 - Workflow and IA source of truth: [V2_WORKFLOW_IA.md](V2_WORKFLOW_IA.md)
 - Evidence schema source of truth: [V2_EVIDENCE_SCHEMA.md](V2_EVIDENCE_SCHEMA.md)
+

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1458,3 +1458,19 @@ Status: Complete
 - Verification:
   - `$env:PYTHONPATH='src'; python -m pytest tests/test_bootstrap.py tests/test_release_scorecard.py tests/test_preflight.py -q` -> `24 passed`
   - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate local-verify` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_local-verify_20260418t164745z.json`; latest pointer refreshed at `runs/verify/latest.json`; preflight artifact written under `runs/preflight/2026-04-18_local-verify_20260418t164745z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_local-verify_20260418t164745z.*`
+
+## Session 82 - Post-Merge Status Sync
+Date: 2026-04-18
+Status: Complete
+
+- Synced the repo-status docs and active milestone issues to the merged `#27` release-evidence state instead of leaving the codebase framed by pre-merge March notes.
+- What changed:
+  - `README.md`, `AGENTS.md`, `docs/HANDOFF.md`, `docs/heartbeat.md`, `docs/repo-brief.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/BUILD_CHECKLIST.md`, `docs/DECISION_LOG.md`, and `docs/V2_RELEASE_RUBRIC.md` now reflect the live repo name, current test count, current `#27` status, and the merged verify-evidence workflow.
+  - Broken GitHub issue links pointing at `cat-loss-war-room-demo` were updated to the live `cat-loss-war-room` repository across the planning and status docs.
+  - GitHub issues `#6`, `#7`, `#8`, `#9`, and `#27` now include current-status sections that match the merged codebase instead of older March-era progress notes.
+  - `docs/heartbeat.md` and `AGENTS.md` now point builders at the live session log rather than the old one-off March memory file.
+- Why:
+  - the local release-evidence stack was merged cleanly, but the repo still described itself in several places as if that work were pending or as if the old repo slug were still current.
+  - this keeps the repo orientation docs and active issue tracker aligned with the actual codebase before the next implementation slice starts.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate post-merge-status-sync` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_post-merge-status-sync_20260418t170708z.json`; latest pointer refreshed at `runs/verify/latest.json`; preflight artifact written under `runs/preflight/2026-04-18_post-merge-status-sync_20260418t170708z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_post-merge-status-sync_20260418t170708z.*`

--- a/docs/V2_BLUEPRINT.md
+++ b/docs/V2_BLUEPRINT.md
@@ -383,10 +383,10 @@ Measure at least:
 
 Goal: lock the shape of V2 before heavy implementation.
 
-- [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) product foundation
-- [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) workflow + design system
-- [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) canonical evidence graph + audit schema
-- [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) quality rubric + release scorecard
+- [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) product foundation
+- [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) workflow + design system
+- [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) canonical evidence graph + audit schema
+- [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) quality rubric + release scorecard
 
 Exit criteria:
 
@@ -399,10 +399,10 @@ Exit criteria:
 
 Goal: make the existing engine safe to build on.
 
-- [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) typed domain models
-- [#7](https://github.com/itprodirect/cat-loss-war-room-demo/issues/7) retrieval contracts
-- [#8](https://github.com/itprodirect/cat-loss-war-room-demo/issues/8) scenario fixtures
-- [#9](https://github.com/itprodirect/cat-loss-war-room-demo/issues/9) CI quality gates
+- [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) typed domain models
+- [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) retrieval contracts
+- [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) scenario fixtures
+- [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) CI quality gates
 
 Exit criteria:
 
@@ -415,12 +415,12 @@ Exit criteria:
 
 Goal: turn the prototype engine into a usable product workflow.
 
-- [#10](https://github.com/itprodirect/cat-loss-war-room-demo/issues/10) orchestration API
-- [#11](https://github.com/itprodirect/cat-loss-war-room-demo/issues/11) web intake + run status UX
-- [#12](https://github.com/itprodirect/cat-loss-war-room-demo/issues/12) evidence normalization
-- [#13](https://github.com/itprodirect/cat-loss-war-room-demo/issues/13) case-law quality v2
-- [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) AI guardrails + eval harness
-- [#26](https://github.com/itprodirect/cat-loss-war-room-demo/issues/26) human review workflow
+- [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) orchestration API
+- [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) web intake + run status UX
+- [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) evidence normalization
+- [#13](https://github.com/itprodirect/cat-loss-war-room/issues/13) case-law quality v2
+- [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) AI guardrails + eval harness
+- [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) human review workflow
 
 Exit criteria:
 
@@ -433,12 +433,12 @@ Exit criteria:
 
 Goal: make V2 pilotable in a serious legal environment.
 
-- [#14](https://github.com/itprodirect/cat-loss-war-room-demo/issues/14) citation verification v2
-- [#15](https://github.com/itprodirect/cat-loss-war-room-demo/issues/15) memo workspace/export v2
-- [#16](https://github.com/itprodirect/cat-loss-war-room-demo/issues/16) firm memory v1
-- [#17](https://github.com/itprodirect/cat-loss-war-room-demo/issues/17) observability + cost controls
-- [#18](https://github.com/itprodirect/cat-loss-war-room-demo/issues/18) security baseline
-- [#19](https://github.com/itprodirect/cat-loss-war-room-demo/issues/19) attorney pilot validation
+- [#14](https://github.com/itprodirect/cat-loss-war-room/issues/14) citation verification v2
+- [#15](https://github.com/itprodirect/cat-loss-war-room/issues/15) memo workspace/export v2
+- [#16](https://github.com/itprodirect/cat-loss-war-room/issues/16) firm memory v1
+- [#17](https://github.com/itprodirect/cat-loss-war-room/issues/17) observability + cost controls
+- [#18](https://github.com/itprodirect/cat-loss-war-room/issues/18) security baseline
+- [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) attorney pilot validation
 
 Exit criteria:
 
@@ -460,7 +460,8 @@ Exit criteria:
 
 ## 13) Immediate Next Actions
 
-1. Finish the remaining typed-domain work in [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) with explicit schema-versioning rules.
-2. Use completed [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) as the bootstrap baseline, then push [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23), [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24), and [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) before major V2 implementation.
+1. Finish the remaining typed-domain work in [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) with explicit schema-versioning rules.
+2. Use completed [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) as the bootstrap baseline, then push [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23), [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24), and [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) before major V2 implementation.
 3. Use the current notebook plus fixture lane as the regression harness while API and web surfaces come online.
-4. Only introduce AI into V2 through the guardrailed path defined in [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25).
+4. Only introduce AI into V2 through the guardrailed path defined in [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25).
+

--- a/docs/V2_ISSUE_MAP.md
+++ b/docs/V2_ISSUE_MAP.md
@@ -8,56 +8,57 @@ Written source-of-truth specs for `#23` and `#24` are complete and those definit
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Program epic | [#3](https://github.com/itprodirect/cat-loss-war-room-demo/issues/3) | Master scope and success criteria |
-| Exa adapter compatibility fix | [#4](https://github.com/itprodirect/cat-loss-war-room-demo/issues/4) | Completed and closed (Mar 4, 2026) |
-| Live-eval intake schema alignment | [#5](https://github.com/itprodirect/cat-loss-war-room-demo/issues/5) | Completed and closed (Mar 5, 2026) |
+| Program epic | [#3](https://github.com/itprodirect/cat-loss-war-room/issues/3) | Master scope and success criteria |
+| Exa adapter compatibility fix | [#4](https://github.com/itprodirect/cat-loss-war-room/issues/4) | Completed and closed (Mar 4, 2026) |
+| Live-eval intake schema alignment | [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) | Completed and closed (Mar 5, 2026) |
 
 ## Phase 1: V2 Framing and Product Foundation
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Product foundation and repo shape | [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) | Completed and closed Mar 6, 2026: packaging/bootstrap landed; app boundaries, envs, local dev, fixture lane documented |
-| Workflow IA and design system | [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) | Written spec complete and issue closed in `docs/V2_WORKFLOW_IA.md`; downstream implementation belongs to `#10` and `#11` |
-| Canonical evidence graph and audit schema | [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) | Written spec complete and issue closed in `docs/V2_EVIDENCE_SCHEMA.md`; downstream implementation belongs to `#6`, `#10`, `#11`, and `#12` |
-| Quality rubric and release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) | First-pass rubric plus fixture-calibrated local scorecard now live in `docs/V2_RELEASE_RUBRIC.md`; explicit demo-ready thresholds are calibrated, and the next step is CI and pilot operationalization |
+| Product foundation and repo shape | [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) | Completed and closed Mar 6, 2026: packaging/bootstrap landed; app boundaries, envs, local dev, fixture lane documented |
+| Workflow IA and design system | [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) | Written spec complete and issue closed in `docs/V2_WORKFLOW_IA.md`; downstream implementation belongs to `#10` and `#11` |
+| Canonical evidence graph and audit schema | [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) | Written spec complete and issue closed in `docs/V2_EVIDENCE_SCHEMA.md`; downstream implementation belongs to `#6`, `#10`, `#11`, and `#12` |
+| Quality rubric and release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) | First-pass rubric plus fixture-calibrated local scorecard now live in `docs/V2_RELEASE_RUBRIC.md`; CI artifact emission and the linked local verify-evidence workflow are landed, and the next step is broader CI and pilot operationalization |
 
 ## Phase 2: Foundation and Quality Gates
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Typed domain models | [#6](https://github.com/itprodirect/cat-loss-war-room-demo/issues/6) | In progress: intake/query, pack, citation/export, graph/version, issue/authority, run/retrieval, and review/export graph-linkage slices are landed against the canonical schema in `#24` |
-| Retrieval adapter contract tests | [#7](https://github.com/itprodirect/cat-loss-war-room-demo/issues/7) | In progress: provider seam, notebook retrieval-state emission, citation-verify tracking, deterministic retrieval-task timing, and Exa compatibility tests landed |
-| Scenario fixture suite | [#8](https://github.com/itprodirect/cat-loss-war-room-demo/issues/8) | Four committed scenario directories now cover Florida, Texas, and Louisiana and feed `#27`; the next step is broader breadth plus comparable thresholds |
-| CI quality gate pipeline | [#9](https://github.com/itprodirect/cat-loss-war-room-demo/issues/9) | Fresh-env + exa compatibility + offline fixture smoke now exist; release-scorecard artifact emission and validation are wired, and the next step is broader CI layering and release-evidence operationalization |
+| Typed domain models | [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) | In progress: intake/query, pack, citation/export, graph/version, issue/authority, run/retrieval, and review/export graph-linkage slices are landed against the canonical schema in `#24` |
+| Retrieval adapter contract tests | [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) | In progress: provider seam, notebook retrieval-state emission, citation-verify tracking, deterministic retrieval-task timing, and Exa compatibility tests landed |
+| Scenario fixture suite | [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) | Four committed scenario directories now cover Florida, Texas, and Louisiana and feed `#27`; the next step is broader breadth plus comparable thresholds |
+| CI quality gate pipeline | [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) | Fresh-env + exa compatibility + offline fixture smoke now exist; release-scorecard artifact emission and validation plus the local verify-evidence workflow are wired, and the next step is broader CI layering, fixture breadth, and failure categorization |
 
 ## Phase 3: Product Core and Human Workflow
 
 | Focus | Issue | Notes |
 |---|---|---|
-| API orchestrator service | [#10](https://github.com/itprodirect/cat-loss-war-room-demo/issues/10) | Move orchestration out of notebook |
-| Web intake and run status UI | [#11](https://github.com/itprodirect/cat-loss-war-room-demo/issues/11) | Non-technical usability, shaped by `#23` |
-| Evidence normalization engine | [#12](https://github.com/itprodirect/cat-loss-war-room-demo/issues/12) | Dedupe, confidence, provenance, built on `#24` |
-| Caselaw quality and filtering v2 | [#13](https://github.com/itprodirect/cat-loss-war-room-demo/issues/13) | Reduce false positives |
-| AI guardrails and eval harness | [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) | Evidence-linked generation only |
-| Human review workflow | [#26](https://github.com/itprodirect/cat-loss-war-room-demo/issues/26) | Approvals, revisions, provenance-preserving edits |
+| API orchestrator service | [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) | Move orchestration out of notebook |
+| Web intake and run status UI | [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) | Non-technical usability, shaped by `#23` |
+| Evidence normalization engine | [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) | Dedupe, confidence, provenance, built on `#24` |
+| Caselaw quality and filtering v2 | [#13](https://github.com/itprodirect/cat-loss-war-room/issues/13) | Reduce false positives |
+| AI guardrails and eval harness | [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) | Evidence-linked generation only |
+| Human review workflow | [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) | Approvals, revisions, provenance-preserving edits |
 
 ## Phase 4: Trust, Scale, and Adoption
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Citation verification hardening | [#14](https://github.com/itprodirect/cat-loss-war-room-demo/issues/14) | Better official-source validation and ambiguity handling |
-| Memo workspace and export v2 | [#15](https://github.com/itprodirect/cat-loss-war-room-demo/issues/15) | Cleaner legal-ready output, paired with `#26` |
-| Firm memory v1 | [#16](https://github.com/itprodirect/cat-loss-war-room-demo/issues/16) | Governed memory after provenance, review, and security mature |
-| Observability and run audit logs | [#17](https://github.com/itprodirect/cat-loss-war-room-demo/issues/17) | Operability and trust |
-| Security and PII controls | [#18](https://github.com/itprodirect/cat-loss-war-room-demo/issues/18) | Production readiness baseline |
-| Pilot validation with attorneys | [#19](https://github.com/itprodirect/cat-loss-war-room-demo/issues/19) | Product-market fit feedback, scored through `#27` |
+| Citation verification hardening | [#14](https://github.com/itprodirect/cat-loss-war-room/issues/14) | Better official-source validation and ambiguity handling |
+| Memo workspace and export v2 | [#15](https://github.com/itprodirect/cat-loss-war-room/issues/15) | Cleaner legal-ready output, paired with `#26` |
+| Firm memory v1 | [#16](https://github.com/itprodirect/cat-loss-war-room/issues/16) | Governed memory after provenance, review, and security mature |
+| Observability and run audit logs | [#17](https://github.com/itprodirect/cat-loss-war-room/issues/17) | Operability and trust |
+| Security and PII controls | [#18](https://github.com/itprodirect/cat-loss-war-room/issues/18) | Production readiness baseline |
+| Pilot validation with attorneys | [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) | Product-market fit feedback, scored through `#27` |
 
 ## Cross-Cutting Workstreams
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Product foundation | [#22](https://github.com/itprodirect/cat-loss-war-room-demo/issues/22) | Unblocks clean implementation of nearly every V2 workstream |
-| UX and design coherence | [#23](https://github.com/itprodirect/cat-loss-war-room-demo/issues/23) | Keeps V2 from devolving into a backend-first tool with thin screens |
-| Provenance and canonical contracts | [#24](https://github.com/itprodirect/cat-loss-war-room-demo/issues/24) | Backbone for evidence trust, review, audit, and export |
-| AI guardrails | [#25](https://github.com/itprodirect/cat-loss-war-room-demo/issues/25) | Required for any serious AI-assisted extraction or drafting |
-| Release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room-demo/issues/27) | Shared benchmark language across CI, dashboards, and pilot work; local artifacts now record committed fixture coverage |
+| Product foundation | [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) | Unblocks clean implementation of nearly every V2 workstream |
+| UX and design coherence | [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) | Keeps V2 from devolving into a backend-first tool with thin screens |
+| Provenance and canonical contracts | [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) | Backbone for evidence trust, review, audit, and export |
+| AI guardrails | [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) | Required for any serious AI-assisted extraction or drafting |
+| Release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) | Shared benchmark language across CI, dashboards, and pilot work; local artifacts now record committed fixture coverage and the supported verify path emits a linked release-evidence bundle |
+

--- a/docs/V2_RELEASE_RUBRIC.md
+++ b/docs/V2_RELEASE_RUBRIC.md
@@ -280,7 +280,7 @@ The local scorecard now evaluates demo-ready fixture calibration against the fol
 
 These thresholds are intentionally scoped to the current demo-ready release level. Beta-ready and Pilot-ready still need broader scenario coverage, stronger output-quality measures, and CI or pilot evidence beyond the local scorecard.
 
-## 8) Current Baseline Snapshot (March 18, 2026)
+## 8) Current Baseline Snapshot (April 18, 2026)
 
 This is the current scorecard entry using the rubric above.
 
@@ -288,12 +288,12 @@ Target release level: `Demo-ready`
 
 | Dimension | Score | Verdict | Why |
 |---|---:|---|---|
-| Reliability | 3 | Strong | `252` tests pass on the supported bootstrap path, CI covers fresh-env plus `exa-py` compatibility, the offline fixture smoke gate is explicit, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
+| Reliability | 3 | Strong | `277` tests pass on the supported verify path, CI covers fresh-env plus `exa-py` compatibility plus offline fixture smoke and release-scorecard artifact validation, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
 | Evidence Quality | 2 | Acceptable | The committed four-scenario fixture set still satisfies explicit demo-ready thresholds for scenario count, state coverage, issue breadth, citation coverage, and module completeness. Broader scenario breadth and richer normalization still remain open under `#8`, `#12`, and `#13`. |
 | Trust and Provenance | 2 | Acceptable | Disclaimers, source tiers, citation checks, evidence clusters, and claim/review trace links exist, but they are still notebook-era rather than full product workflow state. |
 | Workflow Usability | 1 | Weak | The product is still notebook-first and generally engineer-driven for setup and operation, but the notebook/preflight path now exposes a first workflow layer with research-plan preview, cluster-first evidence-board summary, issue-workspace summary, memo-composer readiness, export-history posture, and explicit run-stage review states. |
 | Review and Export Quality | 2 | Acceptable | Memo/export trust signals are stronger and audit structures exist, but export quality is still not polished for repeated client-facing use. |
-| Operational Readiness | 1 | Weak | Bootstrap and runtime boundaries are documented, fixture smoke is now explicit in CI, and local scorecards record fixture coverage, but broader observability and deployment lanes remain future work. |
+| Operational Readiness | 1 | Weak | Bootstrap and runtime boundaries are documented, fixture smoke is explicit in CI, and the supported verify path now emits linked preflight, scorecard, manifest, and latest-pointer artifacts, but broader observability and deployment lanes remain future work. |
 | Security and Governance | 1 | Weak | Safety posture is disciplined for a demo, but production-grade controls are still roadmap items. |
 
 Current verdict:
@@ -382,7 +382,7 @@ Manual and CI-specific scorecard generation still remains available with:
 ```bash
 python -m war_room.release_scorecard \
   --candidate local-demo \
-  --verification-summary "252 passed"
+  --verification-summary "277 passed"
 ```
 
 What it does not do yet:

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -2,14 +2,14 @@
 
 - Repo: `cat-loss-war-room`
 - Current milestone: Stabilize the notebook demo while finishing `#27` and the remaining `#6` to `#9` foundation work.
-- Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; the Milton benchmark trust/readability slice is now closed with cache-backed runtime cleanup for citation trust, carrier/caselaw relevance, and export readability.
-- Current branch: `codex/milton-trust-readability-slice`
-- Last validated: 2026-03-30 via `$env:PYTHONPATH='src'; .venv\Scripts\python.exe -m war_room --verify` (`268 passed, 1 warning`; offline preflight passed for 4 fixture scenarios)
-- Current focus: Close out the Milton benchmark PR cleanly, then return to `#27` operationalization and the remaining `#6` to `#9` foundation work.
-- Hot files: `src/war_room/models.py`, `src/war_room/export_md.py`, `src/war_room/evidence_board.py`, `src/war_room/carrier_module.py`, `src/war_room/caselaw_module.py`, `tests/test_memo_contracts.py`, `tests/test_export.py`, `tests/test_evidence_board.py`, `tests/test_carrier.py`, `tests/test_caselaw.py`, `tests/test_offline_demo_pack.py`
+- Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; the `#27` local release-evidence stack is now merged, including live preflight-backed scorecards, run-scoped verify artifacts, verify manifests, and a stable latest pointer.
+- Current branch: `codex/post-merge-status-sync`
+- Last validated: 2026-04-18 via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate post-merge-status-sync` (`277 passed`; offline preflight passed for 4 fixture scenarios)
+- Current focus: Sync repo-status docs and issue tracking to the merged `#27` release-evidence state, then return to the remaining `#6` to `#9` foundation work.
+- Hot files: `README.md`, `AGENTS.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/repo-brief.md`, `docs/BUILD_CHECKLIST.md`, `docs/V2_RELEASE_RUBRIC.md`
 - Blockers: No hard blocker is documented in-repo; main risks are uneven fixture coverage, notebook-first operator UX, and the current venv not being editable-installed by default.
 - Do not touch this sprint: repo rename, broad product rewrites, placeholder V2 directories as if they were live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
-- Latest session log: `logs/2026-03-27-session.md`
-- Next best task: Return to `#27` release-scorecard operationalization or broaden fixture-quality calibration beyond Milton once this narrow benchmark slice is merged.
+- Latest session log: `docs/SESSION_LOG.md`
+- Next best task: After the doc/issue sync lands, pick the next smallest foundation slice in `#6` or `#9`, with a slight bias toward broader CI layering or the remaining typed-contract seams.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.

--- a/docs/repo-brief.md
+++ b/docs/repo-brief.md
@@ -41,6 +41,7 @@ Preserve the stable V0 notebook demo while finishing the active foundation tranc
 - Citation verification summaries.
 - Markdown research memo exports with disclaimers and audit linkage.
 - Preflight and verification results for demo readiness.
+- Run-scoped preflight, scorecard, and verify-manifest artifacts for the supported local release-evidence path.
 
 ## Quality bar
 


### PR DESCRIPTION
## Summary
- sync repo-status docs to the merged #27 release-evidence state
- fix stale GitHub issue links that still pointed at the old cat-loss-war-room-demo repo
- refresh active issue bodies for #6, #7, #8, #9, and #27 so tracker status matches the current codebase

## Why
- the release-evidence work merged cleanly, but several docs still carried March-era counts, old branch references, stale session-log pointers, and wrong repo issue URLs
- this follow-up keeps repo orientation docs and active milestone tracking aligned with the actual codebase before the next implementation slice

## Validation
- \\$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate post-merge-status-sync\\ -> \\277 passed\\`n- offline preflight passed for 4 committed fixture scenarios
