### PR TITLE
docs: close out final session status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ notebooks/          # Jupyter notebooks (the demo surface)
 cache_samples/      # Committed demo fixtures (run without API key)
 cache/              # Runtime cache (gitignored)
 output/             # Generated reports (gitignored)
-tests/              # pytest test suite (168 tests, no network)
+tests/              # pytest test suite (277 tests, no network)
 scripts/            # Seed scripts (manual, not CI)
 docs/               # Project documentation
 apps/               # V2 app placeholders (web/api)
@@ -82,9 +82,9 @@ Prioritize in this order:
 - `fix/` - bug fixes
 
 ## Current phase
-v0-demo shipped, issues #22, #23, and #24 are complete and closed, and active V2 execution work is now concentrated in #27 and the remaining #6 to #9 foundation slices. Cells 0-7 remain stable and CI runs package-installed tests.
+v0-demo shipped, issues #22, #23, and #24 are complete and closed, and active V2 execution work is now concentrated in broader #27 CI/pilot operationalization plus the remaining #6 to #9 foundation slices. Cells 0-7 remain stable and CI runs package-installed tests.
 
 ## Next session focus
 See [`docs/HANDOFF.md`](docs/HANDOFF.md) for full orientation and status.
 Execution roadmap lives in [`docs/ROADMAP.md`](docs/ROADMAP.md) and [`docs/V2_ISSUE_MAP.md`](docs/V2_ISSUE_MAP.md).
-Next priority: continue #27 operationalization plus the remaining #6, #7, #8, and #9 foundation work, then move downstream implementation into #10 onward.
+Next priority: pick the next small foundation slice in #6 or #9, then continue #7/#8 as needed before moving downstream implementation into #10 onward.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -8,7 +8,7 @@ This file is the front door to the repo's existing memory stack. It points to th
 2. [AGENTS.md](./AGENTS.md)
 3. [docs/repo-brief.md](./docs/repo-brief.md)
 4. [docs/heartbeat.md](./docs/heartbeat.md)
-5. Latest file in [`logs/`](./logs/) (currently [`logs/2026-03-27-session.md`](./logs/2026-03-27-session.md))
+5. Latest file in [`logs/`](./logs/) (currently [`logs/2026-04-28-session.md`](./logs/2026-04-28-session.md))
 6. [docs/DECISION_LOG.md](./docs/DECISION_LOG.md) if the task touches a durable naming, scope, or architecture decision
 
 ## Current operational memory files

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -15,7 +15,7 @@ Given a case intake, it assembles:
 
 This is research acceleration, not legal advice.
 
-## 2) Current status (as of April 18, 2026)
+## 2) Current status (as of April 28, 2026)
 
 | Item | Status |
 |---|---|

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap (Simple, Current)
 
-Last updated: April 18, 2026
+Last updated: April 28, 2026
 
 This is the short version. Clean, practical, no drama.
 
@@ -116,4 +116,3 @@ Goal: trust, polish, and real-world adoption readiness.
 - Release rubric source of truth: [V2_RELEASE_RUBRIC.md](V2_RELEASE_RUBRIC.md)
 - Workflow and IA source of truth: [V2_WORKFLOW_IA.md](V2_WORKFLOW_IA.md)
 - Evidence schema source of truth: [V2_EVIDENCE_SCHEMA.md](V2_EVIDENCE_SCHEMA.md)
-

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1474,3 +1474,23 @@ Status: Complete
   - this keeps the repo orientation docs and active issue tracker aligned with the actual codebase before the next implementation slice starts.
 - Verification:
   - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate post-merge-status-sync` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios; verify manifest written under `runs/verify/2026-04-18_post-merge-status-sync_20260418t170708z.json`; latest pointer refreshed at `runs/verify/latest.json`; preflight artifact written under `runs/preflight/2026-04-18_post-merge-status-sync_20260418t170708z.json`; scorecard artifacts written under `runs/release_scorecards/2026-04-18_post-merge-status-sync_20260418t170708z.*`
+
+## Session 83 - Final Docs Closeout
+Date: 2026-04-28
+Status: Complete
+
+- Ran a final closeout pass after the `#27` release-evidence sync had landed on `main`.
+- What changed:
+  - `docs/HANDOFF.md`, `docs/ROADMAP.md`, and `docs/V2_RELEASE_RUBRIC.md` now carry the April 28 status date.
+  - `docs/heartbeat.md` now points to the closeout branch, latest validation command, current focus, and April 28 session log.
+  - `MEMORY.md` now points to the latest file under `logs/`.
+  - `CLAUDE.md` now reflects the current 277-test baseline and next-session focus.
+  - `docs/repo-brief.md` now describes the remaining `#27` work as broader CI/pilot operationalization rather than the already-merged local verify bundle.
+  - `tests/test_preflight.py` now derives the expected preflight artifact date from the report timestamp instead of hard-coding the prior April 18 validation date.
+  - `logs/2026-04-28-session.md` records the final closeout state for future resumption.
+- Why:
+  - the repo was functionally current, but the end-of-night orientation docs still had a few stale branch/date/session pointers.
+  - the supported verification path exposed one date-rollover test expectation that needed to follow the live preflight report date.
+  - this keeps the memory stack clean before the next foundation slice starts.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios.

--- a/docs/V2_RELEASE_RUBRIC.md
+++ b/docs/V2_RELEASE_RUBRIC.md
@@ -1,6 +1,6 @@
 # V2 Quality Rubric and Release Scorecard
 
-Last updated: April 18, 2026
+Last updated: April 28, 2026
 
 This document is the first-pass output of issue `#27`.
 
@@ -280,7 +280,7 @@ The local scorecard now evaluates demo-ready fixture calibration against the fol
 
 These thresholds are intentionally scoped to the current demo-ready release level. Beta-ready and Pilot-ready still need broader scenario coverage, stronger output-quality measures, and CI or pilot evidence beyond the local scorecard.
 
-## 8) Current Baseline Snapshot (April 18, 2026)
+## 8) Current Baseline Snapshot (April 28, 2026)
 
 This is the current scorecard entry using the rubric above.
 

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -3,13 +3,13 @@
 - Repo: `cat-loss-war-room`
 - Current milestone: Stabilize the notebook demo while finishing `#27` and the remaining `#6` to `#9` foundation work.
 - Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; the `#27` local release-evidence stack is now merged, including live preflight-backed scorecards, run-scoped verify artifacts, verify manifests, and a stable latest pointer.
-- Current branch: `codex/post-merge-status-sync`
-- Last validated: 2026-04-18 via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate post-merge-status-sync` (`277 passed`; offline preflight passed for 4 fixture scenarios)
-- Current focus: Sync repo-status docs and issue tracking to the merged `#27` release-evidence state, then return to the remaining `#6` to `#9` foundation work.
-- Hot files: `README.md`, `AGENTS.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/repo-brief.md`, `docs/BUILD_CHECKLIST.md`, `docs/V2_RELEASE_RUBRIC.md`
+- Current branch: `codex/final-docs-closeout`
+- Last validated: 2026-04-28 via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout` (`277 passed`; offline preflight passed for 4 fixture scenarios)
+- Current focus: Final session closeout docs pass, then return to the remaining `#6` to `#9` foundation work in the next session.
+- Hot files: `README.md`, `AGENTS.md`, `CLAUDE.md`, `MEMORY.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/repo-brief.md`, `docs/BUILD_CHECKLIST.md`, `docs/V2_RELEASE_RUBRIC.md`, `docs/SESSION_LOG.md`, `tests/test_preflight.py`
 - Blockers: No hard blocker is documented in-repo; main risks are uneven fixture coverage, notebook-first operator UX, and the current venv not being editable-installed by default.
 - Do not touch this sprint: repo rename, broad product rewrites, placeholder V2 directories as if they were live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
-- Latest session log: `docs/SESSION_LOG.md`
-- Next best task: After the doc/issue sync lands, pick the next smallest foundation slice in `#6` or `#9`, with a slight bias toward broader CI layering or the remaining typed-contract seams.
+- Latest session log: `logs/2026-04-28-session.md` plus `docs/SESSION_LOG.md`
+- Next best task: Pick the next smallest foundation slice in `#6` or `#9`, with a slight bias toward broader CI layering or the remaining typed-contract seams.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.

--- a/docs/repo-brief.md
+++ b/docs/repo-brief.md
@@ -15,7 +15,7 @@ This repo is the current execution surface for attorney-demo research accelerati
 
 ## Current milestone
 
-Preserve the stable V0 notebook demo while finishing the active foundation tranche: issue `#27` plus the remaining work in `#6`, `#7`, `#8`, and `#9`.
+Preserve the stable V0 notebook demo while finishing the active foundation tranche: broader `#27` CI/pilot operationalization plus the remaining work in `#6`, `#7`, `#8`, and `#9`.
 
 ## Non-goals
 
@@ -60,7 +60,7 @@ Preserve the stable V0 notebook demo while finishing the active foundation tranc
 
 ## Next 3 tasks
 
-1. Continue issue `#27` by operationalizing the release scorecard in CI and pilot evidence without changing the current demo surface.
+1. Continue issue `#27` by broadening CI/pilot release evidence beyond the merged local verify bundle without changing the current demo surface.
 2. Finish the remaining `#6` and `#7` foundation seams so the notebook-era runtime keeps one clear contract path.
 3. Expand `#8` and `#9` with broader fixture coverage and CI quality gates that match the supported offline-demo lane.
 

--- a/logs/2026-04-28-session.md
+++ b/logs/2026-04-28-session.md
@@ -1,0 +1,48 @@
+# Session Log - 2026-04-28
+
+## Objective
+
+Close the night with a final repo orientation pass, fix one date-rollover test expectation exposed by validation, then package the changes for PR review.
+
+## Changes made
+
+- Updated status dates in `docs/HANDOFF.md`, `docs/ROADMAP.md`, and `docs/V2_RELEASE_RUBRIC.md`.
+- Updated `docs/heartbeat.md` for the `codex/final-docs-closeout` branch, current focus, latest validation command, and latest session log.
+- Updated `MEMORY.md` so the memory stack points at this April 28 log.
+- Updated `CLAUDE.md` so its repo layout and next-session focus match the current 277-test baseline and remaining `#6`/`#9` foundation direction.
+- Updated `docs/repo-brief.md` to describe the remaining `#27` work as broader CI/pilot operationalization now that the local verify-evidence bundle is merged.
+- Added the matching `docs/SESSION_LOG.md` entry for this closeout.
+- Updated `tests/test_preflight.py` so its preflight artifact filename assertion derives the expected date from the generated report instead of hard-coding April 18.
+
+## Validation
+
+- `git status --short --branch` before edits: clean branch `codex/final-docs-closeout` from `origin/main`.
+- `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout`
+- Result: `277 passed`; offline preflight passed for 4 committed fixture scenarios.
+
+## Risks found
+
+- No new functional risk found; the only non-doc edit was a date-rollover test-maintenance fix.
+- The primary ongoing product risks remain notebook-first UX, uneven fixture coverage versus the broader registry, and production security/pilot readiness still being future work.
+
+## Follow-up tasks
+
+- Pick the next narrow foundation slice in `#6` or `#9`.
+- Keep broad `#27` follow-up focused on CI/pilot evidence beyond the merged local verify bundle.
+
+## Docs updated
+
+- `CLAUDE.md`
+- `MEMORY.md`
+- `docs/HANDOFF.md`
+- `docs/ROADMAP.md`
+- `docs/V2_RELEASE_RUBRIC.md`
+- `docs/heartbeat.md`
+- `docs/repo-brief.md`
+- `docs/SESSION_LOG.md`
+- `logs/2026-04-28-session.md`
+- `tests/test_preflight.py`
+
+## Recommended next prompt
+
+Continue from `docs/heartbeat.md` and implement the smallest useful `#6` or `#9` foundation slice without changing the notebook demo surface.

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -114,7 +114,8 @@ def test_write_preflight_artifact_writes_json_payload(tmp_path: Path):
     )
 
     assert output_path.exists()
-    assert output_path.name == f"2026-04-18_local-verify_{run_id.lower()}.json"
+    artifact_date = report.created_at[:10]
+    assert output_path.name == f"{artifact_date}_local-verify_{run_id.lower()}.json"
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["run_id"] == run_id
     assert payload["passed"] is True


### PR DESCRIPTION
## Summary
- sync final closeout status dates and heartbeat/memory pointers
- add the 2026-04-28 session log
- fix the preflight artifact test so expected filenames use the report date instead of April 18

## Validation
- $env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout
- Result: 277 passed; offline preflight passed for 4 committed fixture scenarios