### PR TITLE
test: guard export readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ notebooks/          # Jupyter notebooks (the demo surface)
 cache_samples/      # Committed demo fixtures (run without API key)
 cache/              # Runtime cache (gitignored)
 output/             # Generated reports (gitignored)
-tests/              # pytest test suite (277 tests, no network)
+tests/              # pytest test suite (279 tests, no network)
 scripts/            # Seed scripts (manual, not CI)
 docs/               # Project documentation
 apps/               # V2 app placeholders (web/api)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Only the Milton benchmark currently has committed offline cache fixtures, so cac
 
 ## Current Status
 
-**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `277` tests are passing under the supported bootstrap path, the supported `--verify` flow now writes a linked run-scoped release-evidence bundle, and CI now enforces:
+**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `279` tests are passing under the supported bootstrap path, the supported `--verify` flow now writes a linked run-scoped release-evidence bundle, and CI now enforces:
 - Fresh environment install + full test run
 - Editable package bootstrap validation
 - Offline fixture smoke validation across committed scenarios
@@ -150,4 +150,3 @@ This tool is a research accelerator, not a legal oracle. All outputs carry:
 - "DRAFT - ATTORNEY WORK PRODUCT" watermarks on exports
 
 No output should be used without independent verification by a licensed attorney.
-

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -21,7 +21,7 @@ This is research acceleration, not legal advice.
 |---|---|
 | Notebook cells 0-7 | Working |
 | Offline demo (`USE_CACHE=true`) | Working |
-| Tests | 277 passing under the supported verify path after editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
+| Tests | 279 passing under the supported verify path after editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
 | CI | Fresh-env test gate + offline fixture smoke gate + exa-py compatibility matrix + release-scorecard artifact job with artifact validation, all using editable package install |
 | Exa compatibility hardening (`#4`) | Complete and closed |
 | Intake schema alignment (`#5`) | Complete and closed |
@@ -57,6 +57,7 @@ This is research acceleration, not legal advice.
 - The supported verify flow now emits a linked release-evidence bundle: run-scoped preflight artifacts, run-scoped scorecards, verify manifests, a stable `runs/verify/latest.json` pointer, and an integrity test that reloads the linked artifact set.
 - The notebook and preflight surfaces now expose a workflow-oriented research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run timeline, so grouped support, issue-level review, section readiness, export posture, and review-required state are visible before the memo is treated as complete.
 - The Milton benchmark fixture lane now normalizes cached citation trust metadata, carrier/case-law runtime quality, and markdown/export readability without changing the scenario registry or overall notebook-era runtime flow.
+- The Milton rendered-memo path now has an export readability guard that blocks obvious mojibake, scraped navigation text, generic weather pages, Casetext boilerplate, and broken markdown-table rows from reappearing in demo output.
 
 ## 4) Quick run
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,12 +7,13 @@ This is the short version. Clean, practical, no drama.
 ## Where we are now
 
 - Demo pipeline is stable.
-- 277 tests are passing on the supported verify path.
+- 279 tests are passing on the supported verify path.
 - CI has a fresh-environment gate, editable-package install, an explicit offline fixture smoke job, and the `exa-py` compatibility matrix.
 - CI now also emits and validates a release-scorecard artifact from the calibrated `#27` workflow.
 - The supported test path is editable install plus `pytest -q`, or `PYTHONPATH=src` for ad hoc local runs. Raw-checkout `pytest -q` is not supported.
 - The offline demo path now has a deterministic preflight command: `python -m war_room --preflight`.
 - The notebook and preflight surfaces now expose a first workflow layer with research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline review state.
+- The Milton rendered memo now has a focused readability guard for mojibake, scraped navigation text, generic weather pages, Casetext boilerplate, and markdown table alignment.
 - A deeper V2 foundation layer is tracked in issues `#22` through `#27`.
 - Issue [#4](https://github.com/itprodirect/cat-loss-war-room/issues/4) is complete and closed.
 - Issue [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) is complete and closed.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1494,3 +1494,21 @@ Status: Complete
   - this keeps the memory stack clean before the next foundation slice starts.
 - Verification:
   - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout` -> passed, `277 passed`; offline preflight passed for 4 committed fixture scenarios.
+
+## Session 84 - Export Readability Guard
+Date: 2026-04-28 local / 2026-04-29 UTC
+Status: Complete
+
+- Added a focused guard for the rendered Milton memo so embarrassing demo-output regressions fail in tests instead of surfacing in a walkthrough.
+- What changed:
+  - `tests/test_export.py` now renders the Milton fixture path through the runtime modules and asserts the memo keeps required demo sections and disclaimers.
+  - The same export test now rejects obvious mojibake prefixes, `CONTINUE TO SITE`, weather navigation text, Casetext boilerplate, generic weather pages, and filler carrier rows.
+  - `tests/test_export.py` also checks contiguous markdown table blocks for stable pipe counts, catching table-cell escaping regressions.
+  - `src/war_room/weather_module.py` now normalizes cached/live weather payloads before memo and workflow consumers see them, dropping stale navigation-heavy observations and generic low-value weather sources from older cache samples.
+  - Active status docs now reflect the 279-test baseline.
+- Why:
+  - the prior runtime was cleaner than the old notebook-era output, but the top-level Milton weather cache still leaked stale navigation text into the rendered memo.
+  - this keeps the default demo memo credible without broad fixture rewrites, new dependencies, or changes to the notebook surface.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_export.py tests/test_weather.py tests/test_offline_demo_pack.py -q` -> `62 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard` -> passed, `279 passed`; offline preflight passed for 4 committed fixture scenarios; Milton weather sources reduced to 9 after cached weather normalization.

--- a/docs/V2_RELEASE_RUBRIC.md
+++ b/docs/V2_RELEASE_RUBRIC.md
@@ -288,7 +288,7 @@ Target release level: `Demo-ready`
 
 | Dimension | Score | Verdict | Why |
 |---|---:|---|---|
-| Reliability | 3 | Strong | `277` tests pass on the supported verify path, CI covers fresh-env plus `exa-py` compatibility plus offline fixture smoke and release-scorecard artifact validation, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
+| Reliability | 3 | Strong | `279` tests pass on the supported verify path, CI covers fresh-env plus `exa-py` compatibility plus offline fixture smoke and release-scorecard artifact validation, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
 | Evidence Quality | 2 | Acceptable | The committed four-scenario fixture set still satisfies explicit demo-ready thresholds for scenario count, state coverage, issue breadth, citation coverage, and module completeness. Broader scenario breadth and richer normalization still remain open under `#8`, `#12`, and `#13`. |
 | Trust and Provenance | 2 | Acceptable | Disclaimers, source tiers, citation checks, evidence clusters, and claim/review trace links exist, but they are still notebook-era rather than full product workflow state. |
 | Workflow Usability | 1 | Weak | The product is still notebook-first and generally engineer-driven for setup and operation, but the notebook/preflight path now exposes a first workflow layer with research-plan preview, cluster-first evidence-board summary, issue-workspace summary, memo-composer readiness, export-history posture, and explicit run-stage review states. |
@@ -382,7 +382,7 @@ Manual and CI-specific scorecard generation still remains available with:
 ```bash
 python -m war_room.release_scorecard \
   --candidate local-demo \
-  --verification-summary "277 passed"
+  --verification-summary "279 passed"
 ```
 
 What it does not do yet:

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -3,13 +3,13 @@
 - Repo: `cat-loss-war-room`
 - Current milestone: Stabilize the notebook demo while finishing `#27` and the remaining `#6` to `#9` foundation work.
 - Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; the `#27` local release-evidence stack is now merged, including live preflight-backed scorecards, run-scoped verify artifacts, verify manifests, and a stable latest pointer.
-- Current branch: `codex/final-docs-closeout`
-- Last validated: 2026-04-28 via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate final-docs-closeout` (`277 passed`; offline preflight passed for 4 fixture scenarios)
-- Current focus: Final session closeout docs pass, then return to the remaining `#6` to `#9` foundation work in the next session.
-- Hot files: `README.md`, `AGENTS.md`, `CLAUDE.md`, `MEMORY.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/repo-brief.md`, `docs/BUILD_CHECKLIST.md`, `docs/V2_RELEASE_RUBRIC.md`, `docs/SESSION_LOG.md`, `tests/test_preflight.py`
+- Current branch: `codex/export-readability-guard`
+- Last validated: 2026-04-28 local / 2026-04-29 UTC via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard` (`279 passed`; offline preflight passed for 4 fixture scenarios)
+- Current focus: Export readability guard for the Milton memo path, keeping stale navigation text, mojibake, generic weather pages, Casetext boilerplate, and table drift out of demo output.
+- Hot files: `README.md`, `CLAUDE.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/heartbeat.md`, `docs/SESSION_LOG.md`, `logs/2026-04-28-session.md`, `src/war_room/weather_module.py`, `tests/test_export.py`
 - Blockers: No hard blocker is documented in-repo; main risks are uneven fixture coverage, notebook-first operator UX, and the current venv not being editable-installed by default.
 - Do not touch this sprint: repo rename, broad product rewrites, placeholder V2 directories as if they were live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
 - Latest session log: `logs/2026-04-28-session.md` plus `docs/SESSION_LOG.md`
-- Next best task: Pick the next smallest foundation slice in `#6` or `#9`, with a slight bias toward broader CI layering or the remaining typed-contract seams.
+- Next best task: Review and merge the export readability guard PR, then pick the next smallest `#6` or `#9` foundation slice.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.

--- a/logs/2026-04-28-session.md
+++ b/logs/2026-04-28-session.md
@@ -46,3 +46,29 @@ Close the night with a final repo orientation pass, fix one date-rollover test e
 ## Recommended next prompt
 
 Continue from `docs/heartbeat.md` and implement the smallest useful `#6` or `#9` foundation slice without changing the notebook demo surface.
+
+## Follow-up Slice - Export Readability Guard
+
+### Objective
+
+Add a small, high-leverage guard so the rendered Milton memo does not regress into mojibake, stale scraped navigation text, generic weather pages, Casetext boilerplate, or broken markdown tables.
+
+### Changes made
+
+- Added a rendered Milton fixture memo guard in `tests/test_export.py`.
+- Added markdown table pipe-count validation for rendered memo tables.
+- Normalized cached/live weather payloads in `src/war_room/weather_module.py` before memo and workflow rendering.
+- Dropped navigation-heavy weather observations and low-value generic weather sources from older top-level cache samples at runtime.
+- Updated active docs and session memory for the 279-test baseline.
+
+### Validation
+
+- `$env:PYTHONPATH='src'; python -m pytest tests/test_export.py tests/test_weather.py tests/test_offline_demo_pack.py -q`
+- Result: `62 passed`.
+- `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard`
+- Result: `279 passed`; offline preflight passed for 4 committed fixture scenarios.
+
+### Follow-up tasks
+
+- Review and merge the export readability guard PR.
+- Continue with the next small `#6` or `#9` foundation slice after merge.

--- a/src/war_room/weather_module.py
+++ b/src/war_room/weather_module.py
@@ -6,6 +6,7 @@ Extracts metrics only when present in retrieved content.
 
 from __future__ import annotations
 
+import html
 import re
 from typing import Any, Mapping, Sequence
 
@@ -52,6 +53,9 @@ _NAVIGATION_MARKERS = (
     "[home]",
     "[mobile site]",
     "[text version]",
+    "![skip navigation links]",
+    "mobile site",
+    "text version",
     "skip navigation",
     "storm events database - event details",
 )
@@ -79,7 +83,7 @@ def build_weather_brief(
             if cached is None:
                 cached = cache_get(case_key, cache_dir)
             if cached is not None:
-                return cached
+                return _normalize_weather_brief(cached, intake)
         return _empty_weather_brief(
             intake,
             "No Exa client available and no cached weather brief found.",
@@ -125,12 +129,15 @@ def build_weather_brief(
         payload["run_events"] = run_events
         return weather_brief_to_payload(payload)
 
-    return cached_call(
-        case_key,
-        _fetch,
-        cache_samples_dir=cache_samples_dir,
-        cache_dir=cache_dir,
-        use_cache=use_cache,
+    return _normalize_weather_brief(
+        cached_call(
+            case_key,
+            _fetch,
+            cache_samples_dir=cache_samples_dir,
+            cache_dir=cache_dir,
+            use_cache=use_cache,
+        ),
+        intake,
     )
 
 
@@ -160,6 +167,65 @@ def _empty_weather_brief(intake: CaseIntake, reason: str) -> dict[str, Any]:
         "sources": [],
         "warnings": [reason],
     })
+
+
+def _normalize_weather_brief(
+    payload: Mapping[str, Any],
+    intake: CaseIntake,
+) -> dict[str, Any]:
+    """Clean cached/live weather payloads before memo and workflow rendering."""
+    brief = weather_brief_to_payload(payload)
+
+    observations = []
+    for observation in brief["key_observations"]:
+        cleaned = _clean_weather_text(observation)
+        if not cleaned:
+            continue
+        if _is_navigation_heavy_text(cleaned) or _is_low_value_weather_text(cleaned):
+            continue
+        if cleaned not in observations:
+            observations.append(cleaned)
+
+    sources = []
+    seen_source_urls: set[str] = set()
+    for source in brief["sources"]:
+        title = _clean_weather_text(source.get("title", ""))
+        url = source.get("url", "")
+        if url and url in seen_source_urls:
+            continue
+        candidate = {
+            **source,
+            "title": title,
+            "reason": _clean_weather_text(source.get("reason", "")),
+        }
+        if _is_low_value_weather_result(candidate):
+            continue
+        if _is_navigation_heavy_text(f"{title} {candidate.get('reason', '')}"):
+            continue
+        if url:
+            seen_source_urls.add(url)
+        score = score_url(url, title)
+        sources.append(
+            {
+                **candidate,
+                "badge": score["badge"],
+                "reason": candidate.get("reason") or score["label"],
+            }
+        )
+
+    return weather_brief_to_payload(
+        {
+            **brief,
+            "event_summary": _clean_weather_text(brief.get("event_summary", "")),
+            "key_observations": observations,
+            "sources": sources,
+            "warnings": [
+                cleaned
+                for warning in brief.get("warnings", [])
+                if (cleaned := _clean_weather_text(warning))
+            ],
+        }
+    )
 
 
 def _assemble_brief(
@@ -261,12 +327,11 @@ def _has_location_signal(result: dict[str, Any], intake: CaseIntake) -> bool:
 
 
 def _extract_observation(result: dict[str, Any], intake: CaseIntake) -> str | None:
-    snippet = " ".join((result.get("snippet", "") or "").split())
+    snippet = _clean_weather_text(result.get("snippet", ""))
     if not snippet:
         return None
 
-    lowered = snippet.lower()
-    if any(marker in lowered for marker in _NAVIGATION_MARKERS):
+    if _is_navigation_heavy_text(snippet):
         return None
     if not (_has_location_signal(result, intake) or _is_report_like(result)):
         return None
@@ -281,6 +346,23 @@ def _is_report_like(result: dict[str, Any]) -> bool:
 
 def _contains_any(text: str, needles: tuple[str, ...]) -> bool:
     return any(needle in text for needle in needles)
+
+
+def _clean_weather_text(value: Any) -> str:
+    text = html.unescape(str(value or ""))
+    text = text.replace("\r", " ").replace("\n", " ")
+    text = re.sub(r"!\[([^\]]*)\](?:\([^)]*\))?", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]", r"\1", text)
+    text = re.sub(r"[#*`]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _is_navigation_heavy_text(text: str) -> bool:
+    return _contains_any(text.lower(), _NAVIGATION_MARKERS)
+
+
+def _is_low_value_weather_text(text: str) -> bool:
+    return _contains_any(text.lower(), _LOW_VALUE_WEATHER_TERMS)
 
 
 def _extract_metrics(text: str) -> dict[str, Any]:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,9 +1,39 @@
 """Tests for export_md module - no network calls."""
 
 import tempfile
+from pathlib import Path
 
+from war_room.carrier_module import build_carrier_doc_pack
+from war_room.caselaw_module import build_caselaw_pack
+from war_room.citation_verify import spot_check_citations
 from war_room.export_md import render_markdown_memo, write_markdown
 from war_room.models import CaseIntake, QuerySpec
+from war_room.query_plan import generate_query_plan
+from war_room.weather_module import build_weather_brief
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CACHE_SAMPLES_ROOT = ROOT / "cache_samples"
+
+_MILTON_EXPORT_NOISE_MARKERS = (
+    "\u00e2\u20ac",  # Common UTF-8 mojibake prefix: â€...
+    "\u00f0\u0178",  # Common emoji mojibake prefix: ðŸ...
+    "CONTINUE TO SITE",
+    "Skip Navigation",
+    "Mobile Site",
+    "Text Version",
+    "| Casetext Search + Citator",
+    "Citing Cases",
+    "[![Skip Navigation Links]]",
+    "Hurricane Costs",
+    "News and Media: Disaster 4834",
+    "DR-4834 Public Notice 001",
+    "Potentially relevant carrier document",
+)
+
+
+class _FixtureProvider:
+    provider_name = "fixture"
 
 
 def _sample_data():
@@ -104,6 +134,70 @@ def _sample_data():
     return intake, weather, carrier, caselaw, citecheck, queries
 
 
+def _milton_fixture_memo() -> str:
+    intake = CaseIntake(
+        event_name="Hurricane Milton",
+        event_date="2024-10-09",
+        state="FL",
+        county="Pinellas",
+        carrier="Citizens Property Insurance",
+        policy_type="HO-3 Dwelling",
+        posture=["denial", "bad_faith"],
+        key_facts=[
+            "Category 3 at landfall near Siesta Key",
+            "Roof damage and water intrusion reported within 48 hours",
+            "Claim denied citing pre-existing conditions",
+        ],
+        coverage_issues=[
+            "wind vs water causation",
+            "anti-concurrent causation clause",
+            "duty to investigate",
+        ],
+    )
+    cache_samples_dir = str(CACHE_SAMPLES_ROOT)
+    query_plan = generate_query_plan(intake)
+    weather = build_weather_brief(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=cache_samples_dir,
+    )
+    carrier = build_carrier_doc_pack(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=cache_samples_dir,
+    )
+    caselaw = build_caselaw_pack(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=cache_samples_dir,
+    )
+    citecheck = spot_check_citations(
+        caselaw,
+        _FixtureProvider(),
+        cache_samples_dir=cache_samples_dir,
+    )
+
+    return render_markdown_memo(intake, weather, carrier, caselaw, citecheck, query_plan)
+
+
+def _markdown_table_blocks(markdown: str) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    current: list[str] = []
+    for line in markdown.splitlines():
+        if line.startswith("|"):
+            current.append(line)
+            continue
+        if current:
+            blocks.append(current)
+            current = []
+    if current:
+        blocks.append(current)
+    return blocks
+
+
 def test_render_contains_all_sections():
     md = render_markdown_memo(*_sample_data())
     assert "DRAFT" in md
@@ -121,6 +215,30 @@ def test_render_contains_all_sections():
     assert "Evidence Index" in md
     assert "All Sources" in md
     assert "Methodology" in md
+
+
+def test_milton_fixture_render_is_demo_readable():
+    md = _milton_fixture_memo()
+
+    assert "DEMO RESEARCH MEMO - VERIFY CITATIONS - NOT LEGAL ADVICE" in md
+    assert "Hurricane Milton" in md
+    assert "Pinellas County, FL" in md
+    assert "Citizens Property Insurance" in md
+    assert "## Weather Corroboration" in md
+    assert "## Carrier Document Pack" in md
+    assert "## Case Law" in md
+    assert "### Citation Spot-Check" in md
+
+    for marker in _MILTON_EXPORT_NOISE_MARKERS:
+        assert marker not in md
+
+
+def test_milton_fixture_render_keeps_markdown_tables_aligned():
+    md = _milton_fixture_memo()
+
+    for block in _markdown_table_blocks(md):
+        pipe_counts = {line.count("|") for line in block}
+        assert len(pipe_counts) == 1, block
 
 
 def test_render_contains_case_details():


### PR DESCRIPTION
## Summary
- add a rendered Milton memo guard for mojibake, stale navigation text, generic weather pages, Casetext boilerplate, filler rows, and table alignment
- normalize cached/live weather payloads before memo and workflow rendering so old top-level cache samples do not leak stale weather navigation text
- update active repo docs/session memory to the 279-test baseline

## Validation
- $env:PYTHONPATH='src'; python -m pytest tests/test_export.py tests/test_weather.py tests/test_offline_demo_pack.py -q -> 62 passed
- $env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard -> 279 passed; offline preflight passed for 4 committed fixture scenarios