### PR TITLE
feat: add schema-versioned cache envelopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ notebooks/          # Jupyter notebooks (the demo surface)
 cache_samples/      # Committed demo fixtures (run without API key)
 cache/              # Runtime cache (gitignored)
 output/             # Generated reports (gitignored)
-tests/              # pytest test suite (279 tests, no network)
+tests/              # pytest test suite (283 tests, no network)
 scripts/            # Seed scripts (manual, not CI)
 docs/               # Project documentation
 apps/               # V2 app placeholders (web/api)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Only the Milton benchmark currently has committed offline cache fixtures, so cac
 
 ## Current Status
 
-**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `279` tests are passing under the supported bootstrap path, the supported `--verify` flow now writes a linked run-scoped release-evidence bundle, and CI now enforces:
+**Implemented now:** The notebook-first V0 demo is stable, the offline cache-backed lane works across four committed scenario directories spanning Florida, Texas, and Louisiana, the notebook and preflight path now expose a research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline summary on top of the canonical contracts, `283` tests are passing under the supported bootstrap path, the supported `--verify` flow now writes a linked run-scoped release-evidence bundle, and CI now enforces:
 - Fresh environment install + full test run
 - Editable package bootstrap validation
 - Offline fixture smoke validation across committed scenarios
@@ -123,7 +123,7 @@ Only the Milton benchmark currently has committed offline cache fixtures, so cac
 
 **Specified, not built yet:** `docs/V2_WORKFLOW_IA.md`, `docs/V2_EVIDENCE_SCHEMA.md`, and `docs/V2_RELEASE_RUBRIC.md` are the written source-of-truth specs for the current V2 planning layer, while `apps/`, `workers/`, and `packages/` remain placeholder boundaries for later implementation.
 
-Issues `#4`, `#5`, `#22`, `#23`, and `#24` are complete and closed. The written source-of-truth specs for `#23` and `#24` live in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard, CI artifact emission plus validation, and a linked local verify-evidence workflow in `docs/V2_RELEASE_RUBRIC.md`, and remains open for broader CI/pilot operationalization. Issue `#6` is underway with slices 1-7 landed, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
+Issues `#4`, `#5`, `#22`, `#23`, and `#24` are complete and closed. The written source-of-truth specs for `#23` and `#24` live in `docs/V2_WORKFLOW_IA.md` and `docs/V2_EVIDENCE_SCHEMA.md`, while downstream implementation remains tracked in later issues. Issue `#27` now has a calibrated demo-ready scorecard, CI artifact emission plus validation, and a linked local verify-evidence workflow in `docs/V2_RELEASE_RUBRIC.md`, and remains open for broader CI/pilot operationalization. Issue `#6` is underway with slices 1-8 landed, including schema-versioned runtime cache envelopes with legacy raw-cache loading, and issue `#7` has four slices landed: the provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing.
 
 ## Roadmap (Simple)
 

--- a/docs/BUILD_CHECKLIST.md
+++ b/docs/BUILD_CHECKLIST.md
@@ -22,7 +22,7 @@ Simple execution checklist aligned with the live GitHub roadmap.
 ## Immediate Execution Priorities
 
 - [x] [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) intake schema alignment
-- [ ] [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) typed domain models (slices 1-7 complete: intake/query + module packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts)
+- [ ] [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) typed domain models (slices 1-8 complete: intake/query + module packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts + schema-versioned runtime cache envelopes)
 - [ ] [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) retrieval contracts (provider seam + notebook retrieval-state + citation-verify + deterministic retrieval-task timing slices landed)
 - [ ] [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) scenario fixtures + snapshots (four committed scenario directories now cover Florida, Texas, and Louisiana; broader breadth and snapshot thresholds still needed)
 - [ ] [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) expanded CI gates (offline fixture smoke gate, release-scorecard artifact emission plus validation, and the supported local verify-evidence workflow landed; broader CI layering still needed)
@@ -44,4 +44,3 @@ Simple execution checklist aligned with the live GitHub roadmap.
 - [ ] [#19](https://github.com/itprodirect/cat-loss-war-room/issues/19) pilot validation
 - [ ] [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) AI guardrails and eval harness
 - [ ] [#26](https://github.com/itprodirect/cat-loss-war-room/issues/26) human review workflow
-

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -21,11 +21,11 @@ This is research acceleration, not legal advice.
 |---|---|
 | Notebook cells 0-7 | Working |
 | Offline demo (`USE_CACHE=true`) | Working |
-| Tests | 279 passing under the supported verify path after editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
+| Tests | 283 passing under the supported verify path after editable install or `PYTHONPATH=src`; raw-checkout `pytest -q` is not a supported path |
 | CI | Fresh-env test gate + offline fixture smoke gate + exa-py compatibility matrix + release-scorecard artifact job with artifact validation, all using editable package install |
 | Exa compatibility hardening (`#4`) | Complete and closed |
 | Intake schema alignment (`#5`) | Complete and closed |
-| Typed domain contracts (#6) | Slices 1-7 complete (intake/query + packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts) |
+| Typed domain contracts (#6) | Slices 1-8 complete (intake/query + packs + citation/export contracts + graph/version envelopes + issue/authority contracts + run/retrieval lifecycle contracts + review/export graph-linkage contracts + schema-versioned runtime cache envelopes) |
 | Retrieval contracts (#7) | Four slices landed: provider seam, notebook retrieval-state emission, citation-verify retrieval tracking, and deterministic retrieval-task timing |
 | Product foundation (`#22`) | Complete and closed: packaging/bootstrap lane implemented |
 | Workflow IA spec (`#23`) | Complete and closed as the written source of truth in `docs/V2_WORKFLOW_IA.md` |
@@ -58,6 +58,7 @@ This is research acceleration, not legal advice.
 - The notebook and preflight surfaces now expose a workflow-oriented research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run timeline, so grouped support, issue-level review, section readiness, export posture, and review-required state are visible before the memo is treated as complete.
 - The Milton benchmark fixture lane now normalizes cached citation trust metadata, carrier/case-law runtime quality, and markdown/export readability without changing the scenario registry or overall notebook-era runtime flow.
 - The Milton rendered-memo path now has an export readability guard that blocks obvious mojibake, scraped navigation text, generic weather pages, Casetext boilerplate, and broken markdown-table rows from reappearing in demo output.
+- Runtime cache writes now use a small `v2alpha1` schema-versioned envelope, while cache reads still accept the legacy raw JSON fixture shape already committed in `cache_samples/`.
 
 ## 4) Quick run
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,20 +7,21 @@ This is the short version. Clean, practical, no drama.
 ## Where we are now
 
 - Demo pipeline is stable.
-- 279 tests are passing on the supported verify path.
+- 283 tests are passing on the supported verify path.
 - CI has a fresh-environment gate, editable-package install, an explicit offline fixture smoke job, and the `exa-py` compatibility matrix.
 - CI now also emits and validates a release-scorecard artifact from the calibrated `#27` workflow.
 - The supported test path is editable install plus `pytest -q`, or `PYTHONPATH=src` for ad hoc local runs. Raw-checkout `pytest -q` is not supported.
 - The offline demo path now has a deterministic preflight command: `python -m war_room --preflight`.
 - The notebook and preflight surfaces now expose a first workflow layer with research-plan preview, evidence-board summary, issue-workspace summary, memo-composer summary, export-history summary, and run-timeline review state.
 - The Milton rendered memo now has a focused readability guard for mojibake, scraped navigation text, generic weather pages, Casetext boilerplate, and markdown table alignment.
+- Runtime cache writes now carry a `v2alpha1` schema-versioned envelope while legacy raw fixture caches remain readable.
 - A deeper V2 foundation layer is tracked in issues `#22` through `#27`.
 - Issue [#4](https://github.com/itprodirect/cat-loss-war-room/issues/4) is complete and closed.
 - Issue [#5](https://github.com/itprodirect/cat-loss-war-room/issues/5) is complete and closed.
 - Issue [#22](https://github.com/itprodirect/cat-loss-war-room/issues/22) is complete and closed.
 - Issues [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) and [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) are complete and closed as written source-of-truth specs.
 - Issue [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) is still open, but the local and CI release-evidence path now includes explicit demo-ready threshold calibration, run-scoped artifacts, verify manifests, and a stable latest pointer in `docs/V2_RELEASE_RUBRIC.md`.
-- Issue [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) is in progress (slices 1-7 landed locally; review/export graph-linkage contract slice now added).
+- Issue [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) is in progress (slices 1-8 landed locally; schema-versioned runtime cache envelopes now added).
 - Placeholder directories under `apps/`, `packages/`, and `workers/` are planned V2 boundaries only. The active runtime remains the notebook plus `src/war_room/`.
 
 ## Delivery layers

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -1512,3 +1512,23 @@ Status: Complete
 - Verification:
   - `$env:PYTHONPATH='src'; python -m pytest tests/test_export.py tests/test_weather.py tests/test_offline_demo_pack.py -q` -> `62 passed`
   - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard` -> passed, `279 passed`; offline preflight passed for 4 committed fixture scenarios; Milton weather sources reduced to 9 after cached weather normalization.
+
+## Session 85 - Issue 6 Cache Schema Envelope
+Date: 2026-04-28 local / 2026-04-29 UTC
+Status: Complete
+
+- Continued `#6` by making runtime cache compatibility explicit without changing the committed raw fixture shape.
+- What changed:
+  - `src/war_room/cache_io.py` now writes new cache entries inside a small `war_room.cache_entry` envelope with `schema_version: v2alpha1`.
+  - `cache_get()` unwraps the current envelope transparently so existing module callers still receive the original payload shape.
+  - `cache_get()` remains backward-compatible with legacy raw JSON payloads already present in `cache_samples/` and `cache/`.
+  - Unsupported future cache schema versions now fail explicitly instead of being consumed silently.
+  - `tests/test_cache_io.py` now covers envelope writing, legacy raw-cache loading, unsupported-version rejection, and `cached_call()` runtime writes.
+  - Active status docs now reflect the 283-test baseline and `#6` slice 8.
+- Why:
+  - issue `#6` explicitly calls for schema-versioned cache adapters and backward-compatible loaders.
+  - this gives new runtime cache artifacts a version marker while preserving the offline demo lane and avoiding a broad fixture rewrite.
+- Verification:
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py -q` -> `12 passed`
+  - `$env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py tests/test_offline_demo_pack.py tests/test_weather.py tests/test_carrier.py tests/test_caselaw.py tests/test_citation_verify.py -q` -> `98 passed`
+  - `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate issue-6-cache-envelope` -> passed, `283 passed`; offline preflight passed for 4 committed fixture scenarios.

--- a/docs/V2_ISSUE_MAP.md
+++ b/docs/V2_ISSUE_MAP.md
@@ -25,7 +25,7 @@ Written source-of-truth specs for `#23` and `#24` are complete and those definit
 
 | Focus | Issue | Notes |
 |---|---|---|
-| Typed domain models | [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) | In progress: intake/query, pack, citation/export, graph/version, issue/authority, run/retrieval, and review/export graph-linkage slices are landed against the canonical schema in `#24` |
+| Typed domain models | [#6](https://github.com/itprodirect/cat-loss-war-room/issues/6) | In progress: intake/query, pack, citation/export, graph/version, issue/authority, run/retrieval, review/export graph-linkage, and schema-versioned runtime cache-envelope slices are landed against the canonical schema in `#24` |
 | Retrieval adapter contract tests | [#7](https://github.com/itprodirect/cat-loss-war-room/issues/7) | In progress: provider seam, notebook retrieval-state emission, citation-verify tracking, deterministic retrieval-task timing, and Exa compatibility tests landed |
 | Scenario fixture suite | [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) | Four committed scenario directories now cover Florida, Texas, and Louisiana and feed `#27`; the next step is broader breadth plus comparable thresholds |
 | CI quality gate pipeline | [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) | Fresh-env + exa compatibility + offline fixture smoke now exist; release-scorecard artifact emission and validation plus the local verify-evidence workflow are wired, and the next step is broader CI layering, fixture breadth, and failure categorization |
@@ -61,4 +61,3 @@ Written source-of-truth specs for `#23` and `#24` are complete and those definit
 | Provenance and canonical contracts | [#24](https://github.com/itprodirect/cat-loss-war-room/issues/24) | Backbone for evidence trust, review, audit, and export |
 | AI guardrails | [#25](https://github.com/itprodirect/cat-loss-war-room/issues/25) | Required for any serious AI-assisted extraction or drafting |
 | Release scorecard | [#27](https://github.com/itprodirect/cat-loss-war-room/issues/27) | Shared benchmark language across CI, dashboards, and pilot work; local artifacts now record committed fixture coverage and the supported verify path emits a linked release-evidence bundle |
-

--- a/docs/V2_RELEASE_RUBRIC.md
+++ b/docs/V2_RELEASE_RUBRIC.md
@@ -288,7 +288,7 @@ Target release level: `Demo-ready`
 
 | Dimension | Score | Verdict | Why |
 |---|---:|---|---|
-| Reliability | 3 | Strong | `279` tests pass on the supported verify path, CI covers fresh-env plus `exa-py` compatibility plus offline fixture smoke and release-scorecard artifact validation, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
+| Reliability | 3 | Strong | `283` tests pass on the supported verify path, CI covers fresh-env plus `exa-py` compatibility plus offline fixture smoke and release-scorecard artifact validation, and the committed four-scenario FL/TX/LA lane still meets the calibrated demo-ready thresholds. |
 | Evidence Quality | 2 | Acceptable | The committed four-scenario fixture set still satisfies explicit demo-ready thresholds for scenario count, state coverage, issue breadth, citation coverage, and module completeness. Broader scenario breadth and richer normalization still remain open under `#8`, `#12`, and `#13`. |
 | Trust and Provenance | 2 | Acceptable | Disclaimers, source tiers, citation checks, evidence clusters, and claim/review trace links exist, but they are still notebook-era rather than full product workflow state. |
 | Workflow Usability | 1 | Weak | The product is still notebook-first and generally engineer-driven for setup and operation, but the notebook/preflight path now exposes a first workflow layer with research-plan preview, cluster-first evidence-board summary, issue-workspace summary, memo-composer readiness, export-history posture, and explicit run-stage review states. |
@@ -382,7 +382,7 @@ Manual and CI-specific scorecard generation still remains available with:
 ```bash
 python -m war_room.release_scorecard \
   --candidate local-demo \
-  --verification-summary "279 passed"
+  --verification-summary "283 passed"
 ```
 
 What it does not do yet:

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -3,13 +3,13 @@
 - Repo: `cat-loss-war-room`
 - Current milestone: Stabilize the notebook demo while finishing `#27` and the remaining `#6` to `#9` foundation work.
 - Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`; the `#27` local release-evidence stack is now merged, including live preflight-backed scorecards, run-scoped verify artifacts, verify manifests, and a stable latest pointer.
-- Current branch: `codex/export-readability-guard`
-- Last validated: 2026-04-28 local / 2026-04-29 UTC via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate export-readability-guard` (`279 passed`; offline preflight passed for 4 fixture scenarios)
-- Current focus: Export readability guard for the Milton memo path, keeping stale navigation text, mojibake, generic weather pages, Casetext boilerplate, and table drift out of demo output.
-- Hot files: `README.md`, `CLAUDE.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/heartbeat.md`, `docs/SESSION_LOG.md`, `logs/2026-04-28-session.md`, `src/war_room/weather_module.py`, `tests/test_export.py`
+- Current branch: `codex/issue-6-contract-slice`
+- Last validated: 2026-04-28 local / 2026-04-29 UTC via `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate issue-6-cache-envelope` (`283 passed`; offline preflight passed for 4 fixture scenarios)
+- Current focus: `#6` schema-versioned cache-compatibility slice: runtime cache writes carry a `v2alpha1` envelope, while legacy raw cache fixtures still load.
+- Hot files: `README.md`, `CLAUDE.md`, `docs/BUILD_CHECKLIST.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/V2_ISSUE_MAP.md`, `docs/V2_RELEASE_RUBRIC.md`, `docs/heartbeat.md`, `docs/SESSION_LOG.md`, `logs/2026-04-28-session.md`, `src/war_room/cache_io.py`, `tests/test_cache_io.py`
 - Blockers: No hard blocker is documented in-repo; main risks are uneven fixture coverage, notebook-first operator UX, and the current venv not being editable-installed by default.
 - Do not touch this sprint: repo rename, broad product rewrites, placeholder V2 directories as if they were live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
 - Latest session log: `logs/2026-04-28-session.md` plus `docs/SESSION_LOG.md`
-- Next best task: Review and merge the export readability guard PR, then pick the next smallest `#6` or `#9` foundation slice.
+- Next best task: Review and merge the `#6` cache-envelope PR, then continue replacing the remaining loose dict seams only where the next slice has clear runtime payoff.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.

--- a/logs/2026-04-28-session.md
+++ b/logs/2026-04-28-session.md
@@ -72,3 +72,32 @@ Add a small, high-leverage guard so the rendered Milton memo does not regress in
 
 - Review and merge the export readability guard PR.
 - Continue with the next small `#6` or `#9` foundation slice after merge.
+
+## Follow-up Slice - Issue 6 Cache Schema Envelope
+
+### Objective
+
+Continue `#6` with a narrow cache-compatibility slice: new runtime cache writes should carry an explicit schema version, while existing raw cache fixtures must keep loading.
+
+### Changes made
+
+- Added a `war_room.cache_entry` envelope for new `cache_set()` writes.
+- Stored `schema_version: v2alpha1` on new cache entries, aligned with the current typed-model schema version.
+- Kept `cache_get()` backward-compatible with legacy raw JSON payloads already committed under `cache_samples/`.
+- Added explicit rejection for unsupported cache-envelope schema versions.
+- Added focused cache tests for versioned writes, legacy reads, unsupported versions, and `cached_call()` runtime persistence.
+- Updated active docs and session memory for the 283-test baseline and `#6` slice 8.
+
+### Validation
+
+- `$env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py -q`
+- Result: `12 passed`.
+- `$env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py tests/test_offline_demo_pack.py tests/test_weather.py tests/test_carrier.py tests/test_caselaw.py tests/test_citation_verify.py -q`
+- Result: `98 passed`.
+- `$env:PYTHONPATH='src'; python -m war_room --verify --release-candidate issue-6-cache-envelope`
+- Result: `283 passed`; offline preflight passed for 4 committed fixture scenarios.
+
+### Follow-up tasks
+
+- Review and merge the `#6` cache-envelope PR.
+- Continue replacing remaining loose dict seams only where the next slice has clear runtime payoff.

--- a/src/war_room/cache_io.py
+++ b/src/war_room/cache_io.py
@@ -7,10 +7,16 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
+
+from war_room.models import SCHEMA_VERSION_DEFAULT
+
+CACHE_ENTRY_TYPE = "war_room.cache_entry"
+CACHE_ENTRY_TYPE_KEY = "cache_entry_type"
+CACHE_PAYLOAD_KEY = "payload"
+SUPPORTED_CACHE_SCHEMA_VERSIONS = {SCHEMA_VERSION_DEFAULT}
 
 
 def normalize_key(raw: str) -> str:
@@ -35,7 +41,7 @@ def cache_get(key: str, cache_dir: str | Path) -> Optional[Any]:
     """Read a cached value, or None if not found."""
     path = _cache_path(cache_dir, key)
     if path.exists():
-        return json.loads(path.read_text(encoding="utf-8"))
+        return _unwrap_cache_value(json.loads(path.read_text(encoding="utf-8")))
     return None
 
 
@@ -43,7 +49,10 @@ def cache_set(key: str, value: Any, cache_dir: str | Path) -> Path:
     """Write a value to the cache. Returns the file path."""
     path = _cache_path(cache_dir, key)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, default=str), encoding="utf-8")
+    path.write_text(
+        json.dumps(_wrap_cache_value(value), indent=2, default=str),
+        encoding="utf-8",
+    )
     return path
 
 
@@ -76,3 +85,37 @@ def cached_call(
     result = fn()
     cache_set(key, result, cache_dir)
     return result
+
+
+def _wrap_cache_value(value: Any) -> dict[str, Any]:
+    """Return the current schema-versioned cache envelope for a payload."""
+    if _is_cache_envelope(value):
+        return dict(value)
+    return {
+        CACHE_ENTRY_TYPE_KEY: CACHE_ENTRY_TYPE,
+        "schema_version": SCHEMA_VERSION_DEFAULT,
+        CACHE_PAYLOAD_KEY: value,
+    }
+
+
+def _unwrap_cache_value(raw: Any) -> Any:
+    """Read current cache envelopes while preserving legacy raw-cache payloads."""
+    if not _is_cache_envelope(raw):
+        return raw
+
+    schema_version = str(raw.get("schema_version", "")).strip()
+    if schema_version not in SUPPORTED_CACHE_SCHEMA_VERSIONS:
+        supported = ", ".join(sorted(SUPPORTED_CACHE_SCHEMA_VERSIONS))
+        raise ValueError(
+            f"Unsupported cache schema_version '{schema_version}'. "
+            f"Supported versions: {supported}."
+        )
+    return raw[CACHE_PAYLOAD_KEY]
+
+
+def _is_cache_envelope(value: Any) -> bool:
+    return (
+        isinstance(value, Mapping)
+        and value.get(CACHE_ENTRY_TYPE_KEY) == CACHE_ENTRY_TYPE
+        and CACHE_PAYLOAD_KEY in value
+    )

--- a/tests/test_cache_io.py
+++ b/tests/test_cache_io.py
@@ -1,9 +1,21 @@
 """Tests for cache_io module."""
 
+import json
 import tempfile
 from pathlib import Path
 
-from war_room.cache_io import normalize_key, cache_get, cache_set, cached_call
+import pytest
+
+from war_room.cache_io import (
+    CACHE_ENTRY_TYPE,
+    CACHE_ENTRY_TYPE_KEY,
+    CACHE_PAYLOAD_KEY,
+    cache_get,
+    cache_set,
+    cached_call,
+    normalize_key,
+)
+from war_room.models import SCHEMA_VERSION_DEFAULT
 
 
 def test_normalize_key_basic():
@@ -24,6 +36,48 @@ def test_cache_roundtrip():
         cache_set("test_key", data, tmpdir)
         result = cache_get("test_key", tmpdir)
         assert result == data
+
+
+def test_cache_set_writes_schema_versioned_envelope():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {"results": [1, 2, 3], "query": "test"}
+        path = cache_set("test_key", data, tmpdir)
+        raw = json.loads(path.read_text(encoding="utf-8"))
+
+        assert raw[CACHE_ENTRY_TYPE_KEY] == CACHE_ENTRY_TYPE
+        assert raw["schema_version"] == SCHEMA_VERSION_DEFAULT
+        assert raw[CACHE_PAYLOAD_KEY] == data
+        assert cache_get("test_key", tmpdir) == data
+
+
+def test_cache_get_reads_legacy_unversioned_payload():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        data = {"source": "legacy-fixture"}
+        path = cache_set("legacy_key", {"source": "placeholder"}, tmpdir)
+        path.write_text(
+            json.dumps(data),
+            encoding="utf-8",
+        )
+
+        assert cache_get("legacy_key", tmpdir) == data
+
+
+def test_cache_get_rejects_unsupported_schema_version():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = cache_set("future_key", {"source": "placeholder"}, tmpdir)
+        path.write_text(
+            json.dumps(
+                {
+                    CACHE_ENTRY_TYPE_KEY: CACHE_ENTRY_TYPE,
+                    "schema_version": "v999",
+                    CACHE_PAYLOAD_KEY: {"source": "future"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="Unsupported cache schema_version"):
+            cache_get("future_key", tmpdir)
 
 
 def test_cache_get_missing():
@@ -50,6 +104,23 @@ def test_cached_call_uses_cache():
         result2 = cached_call("my_key", expensive_fn, cache_dir=tmpdir, cache_samples_dir=tmpdir)
         assert result2 == {"value": 42}
         assert call_count == 1  # fn not called again
+
+
+def test_cached_call_writes_schema_versioned_runtime_cache():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = cached_call(
+            "my_key",
+            lambda: {"value": 42},
+            cache_dir=tmpdir,
+            cache_samples_dir=tmpdir,
+        )
+        cache_files = list(Path(tmpdir).glob("*.json"))
+        raw = json.loads(cache_files[0].read_text(encoding="utf-8"))
+
+        assert result == {"value": 42}
+        assert len(cache_files) == 1
+        assert raw["schema_version"] == SCHEMA_VERSION_DEFAULT
+        assert raw[CACHE_PAYLOAD_KEY] == {"value": 42}
 
 
 def test_cached_call_bypass_cache():


### PR DESCRIPTION
## Summary
- continue #6 with schema-versioned runtime cache envelopes using the existing v2alpha1 typed-contract version
- keep cache_get backward-compatible with legacy raw JSON cache fixtures already committed under cache_samples/ and cache/
- reject unsupported future cache-envelope versions explicitly instead of silently consuming unknown shapes
- update repo status docs/session memory to slice 8 and the 283-test baseline

## Validation
- $env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py -q -> 12 passed
- $env:PYTHONPATH='src'; python -m pytest tests/test_cache_io.py tests/test_offline_demo_pack.py tests/test_weather.py tests/test_carrier.py tests/test_caselaw.py tests/test_citation_verify.py -q -> 98 passed
- $env:PYTHONPATH='src'; python -m war_room --verify --release-candidate issue-6-cache-envelope -> 283 passed; offline preflight passed for 4 committed fixture scenarios