### PR TITLE
[codex] normalize citecheck cache badges

### DIFF
--- a/cache_samples/citecheck_citizens_immune_from_bad_faith_not_liable_for_non_contractual_damages_court_e1c4ddac55e2c479.json
+++ b/cache_samples/citecheck_citizens_immune_from_bad_faith_not_liable_for_non_contractual_damages_court_e1c4ddac55e2c479.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.insurancejournal.com/news/southeast/2021/01/29/599257.htm",
   "note": "Found on professional source: www.insurancejournal.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_citizens_property_insurance_corporation_7d3a44a8e2c466d6.json
+++ b/cache_samples/citecheck_citizens_property_insurance_corporation_7d3a44a8e2c466d6.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.citizensfla.com/",
   "note": "Found on www.citizensfla.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_citizens_property_insurance_immunity_from_bad_faith_641ab5f5bb7b8e5d.json
+++ b/cache_samples/citecheck_citizens_property_insurance_immunity_from_bad_faith_641ab5f5bb7b8e5d.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://law.justia.com/cases/florida/supreme-court/2015/sc14-185.html",
   "note": "Found on law.justia.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_citizens_property_insurance_immunity_from_bad_faith_insurance_3a747665ebfc76c4.json
+++ b/cache_samples/citecheck_citizens_property_insurance_immunity_from_bad_faith_insurance_3a747665ebfc76c4.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.rumberger.com/insights/first-dca-denies-citizens-property-insurance-corporation-immunity-from-bad-faith-claims/",
   "note": "Found on www.rumberger.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_concurrent_causation_in_florida_992f9a76ce62ba69.json
+++ b/cache_samples/citecheck_concurrent_causation_in_florida_992f9a76ce62ba69.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://lozanoadjusters.com/understanding-concurrent-causation-and-anti-concurrent-causation-clauses-in-insurance-claims/",
   "note": "Found on lozanoadjusters.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_florida_court_rules_on_concurrent_causation_edd5fe5df091305b.json
+++ b/cache_samples/citecheck_florida_court_rules_on_concurrent_causation_edd5fe5df091305b.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.gray-robinson.com/docs/Jack-R-Reiter-Law360-The-Current-Status-of-Florida's-Concurrent-Cause-Doctrine.pdf",
   "note": "Found on www.gray-robinson.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_florida_s_citizens_property_insurance_may_be_immune_from_bad_7aa0ee4f1fdc224b.json
+++ b/cache_samples/citecheck_florida_s_citizens_property_insurance_may_be_immune_from_bad_7aa0ee4f1fdc224b.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.insurancebusinessmag.com/us/news/claims/florida-court-hits-citizens-property-over-blocked-roof-damage-claim-539713.aspx",
   "note": "Found on www.insurancebusinessmag.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_homeowner_claims_help_7f650b49f26af910.json
+++ b/cache_samples/citecheck_homeowner_claims_help_7f650b49f26af910.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.travelers.com/resources/home/insuring/how-the-home-insurance-claim-process-works",
   "note": "Found on www.travelers.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_hurricane_irma_the_state_of_concurrent_causation_and_acc_clauses_in_florida_jd_supra_208_so_3d_694_44bf147c1aa1d576.json
+++ b/cache_samples/citecheck_hurricane_irma_the_state_of_concurrent_causation_and_acc_clauses_in_florida_jd_supra_208_so_3d_694_44bf147c1aa1d576.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.propertyinsurancecoveragelaw.com/blog/concurrent-causation-in-florida/",
   "note": "Found on professional source: www.propertyinsurancecoveragelaw.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_johnson_v_davis_480_so_2d_625_480_so_2d_625_47f515092d3bcb1c.json
+++ b/cache_samples/citecheck_johnson_v_davis_480_so_2d_625_480_so_2d_625_47f515092d3bcb1c.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://casetext.com/case/johnson-v-davis-20",
   "note": "Found on professional source: casetext.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_notification_to_all_authorized_residential_property_insurers_0172f5645c958b0b.json
+++ b/cache_samples/citecheck_notification_to_all_authorized_residential_property_insurers_0172f5645c958b0b.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://content.govdelivery.com/accounts/FLOIR/bulletins/3d319a7",
   "note": "Found on content.govdelivery.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_quesada_v_director_fed_emergency_agency_753_f_2d_1011_753_f_2d_1011_2a3eba71c0ef37cd.json
+++ b/cache_samples/citecheck_quesada_v_director_fed_emergency_agency_753_f_2d_1011_753_f_2d_1011_2a3eba71c0ef37cd.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://casetext.com/case/quesada-v-director-fed-emergency-agency",
   "note": "Found on professional source: casetext.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_quesada_v_director_federal_emergency_mgmt_agency_577_f_supp_695_577_f_supp_695_87f985b4b1d4a9e3.json
+++ b/cache_samples/citecheck_quesada_v_director_federal_emergency_mgmt_agency_577_f_supp_695_577_f_supp_695_87f985b4b1d4a9e3.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://casetext.com/case/quesada-v-director-federal-emergency-mgmt-agency",
   "note": "Found on professional source: casetext.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_sapuppo_v_allstate_floridian_ins_co_739_f_3d_678_739_f_3d_678_4e3130f4b9c98b9d.json
+++ b/cache_samples/citecheck_sapuppo_v_allstate_floridian_ins_co_739_f_3d_678_739_f_3d_678_4e3130f4b9c98b9d.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://casetext.com/case/sapuppo-v-allstate-floridian-ins-co",
   "note": "Found on professional source: casetext.com \u2014 verify independently"
 }

--- a/cache_samples/citecheck_siegle_v_progressive_consumers_ins_co_819_so_2d_732_819_so_2d_732_181a075e6c679aa3.json
+++ b/cache_samples/citecheck_siegle_v_progressive_consumers_ins_co_819_so_2d_732_819_so_2d_732_181a075e6c679aa3.json
@@ -1,6 +1,6 @@
 {
   "status": "verified",
-  "badge": "\u2705",
+  "badge": "verified",
   "source_url": "https://supremecourt.flcourts.gov/content/download/343992/file/01-1219_ini.pdf",
   "note": "Found on official source: supremecourt.flcourts.gov"
 }

--- a/cache_samples/citecheck_water_damage_from_hurricanes_what_florida_insurance_actually_covers_insurance_attorney_insurance_claim_lawyer_29dd0eaffa0ada06.json
+++ b/cache_samples/citecheck_water_damage_from_hurricanes_what_florida_insurance_actually_covers_insurance_attorney_insurance_claim_lawyer_29dd0eaffa0ada06.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://yourinsuranceattorney.com/water-damage-from-hurricanes-what-florida-insurance-actually-covers/",
   "note": "Found on yourinsuranceattorney.com \u2014 unvetted source, verify independently"
 }

--- a/cache_samples/citecheck_what_is_an_anti_concurrent_causation_clause_44c6610a4b60cc6b.json
+++ b/cache_samples/citecheck_what_is_an_anti_concurrent_causation_clause_44c6610a4b60cc6b.json
@@ -1,6 +1,6 @@
 {
   "status": "uncertain",
-  "badge": "\u26a0\ufe0f",
+  "badge": "warning",
   "source_url": "https://www.williamspa.com/faq/what-is-an-anti-concurrent-causation-clause/",
   "note": "Found on www.williamspa.com \u2014 unvetted source, verify independently"
 }

--- a/tests/test_offline_demo_pack.py
+++ b/tests/test_offline_demo_pack.py
@@ -143,6 +143,11 @@ _CASE_COMMENTARY_MARKERS = (
 
 _STABLE_SOURCE_BADGES = {"official", "professional", "unvetted", "paywalled"}
 _STABLE_CITATION_BADGES = {"verified", "warning", "not_found"}
+_CITATION_BADGE_FOR_STATUS = {
+    "verified": "verified",
+    "uncertain": "warning",
+    "not_found": "not_found",
+}
 
 
 class _FixtureProvider:
@@ -343,3 +348,17 @@ def test_fixture_badges_use_stable_ascii_tokens(case_key: str):
 
     citecheck = _load(case_key, "citation_verify")
     assert {check["badge"] for check in citecheck["checks"]}.issubset(_STABLE_CITATION_BADGES)
+    for check in citecheck["checks"]:
+        assert check["badge"] == _CITATION_BADGE_FOR_STATUS[check["status"]]
+
+
+@pytest.mark.parametrize(
+    "path",
+    sorted(CACHE_SAMPLES_ROOT.glob("citecheck_*.json")),
+    ids=lambda path: path.name,
+)
+def test_flat_citecheck_cache_badges_use_stable_ascii_tokens(path: Path):
+    data = json.loads(path.read_text(encoding="utf-8-sig"))
+
+    assert data["status"] in _CITATION_BADGE_FOR_STATUS
+    assert data["badge"] == _CITATION_BADGE_FOR_STATUS[data["status"]]


### PR DESCRIPTION
## Summary

Repo hygiene for #65: normalize legacy flat citecheck cache `badge` values to the stable ASCII machine-readable citation badge vocabulary already used by current citation verification output.

Decision: these `badge` fields are machine-readable cache values, not display-only emoji. The mapping applied is representation-only:

- `status="uncertain"` keeps the same status and now uses `badge="warning"` instead of `⚠️`.
- `status="verified"` keeps the same status and now uses `badge="verified"` instead of `✅`.
- Existing ASCII `warning` / `verified` values are left as-is.

No citation verification facts were changed: statuses, source URLs, notes, summaries, and case data are unchanged.

## Changed files

- 17 flat `cache_samples/citecheck_*.json` cache files: badge field only.
- `tests/test_offline_demo_pack.py`: adds regression coverage for flat citecheck cache badge/status alignment and tightens scenario fixture citation badge alignment.

## Snapshot impact

No golden snapshot files changed. `python -m war_room.fixture_snapshots --check` matched the committed snapshot exactly.

## Validation

- `python -m pytest tests/test_offline_demo_pack.py::test_fixture_badges_use_stable_ascii_tokens -q` -> 5 passed
- `python -m pytest tests/test_offline_demo_pack.py::test_flat_citecheck_cache_badges_use_stable_ascii_tokens tests/test_offline_demo_pack.py::test_fixture_badges_use_stable_ascii_tokens -q` -> 31 passed
- `python -m pytest tests/test_scenarios.py tests/test_fixture_snapshots.py tests/test_offline_demo_pack.py -q` -> 85 passed
- `python -m pytest -q` -> 369 passed
- `python -m war_room.fixture_snapshots --check` -> passed; snapshot matched
- `python -m war_room.offline_e2e --check` -> passed; 5/5 scenarios
- `python -m war_room --verify --release-candidate normalize-citecheck-badges` -> passed; embedded `369 passed`
- `git diff --check` -> passed

Closes #65