### PR TITLE
[codex] Add orchestration branch regression tests

### DIFF
--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -15,6 +15,7 @@ from war_room.orchestration import (
     UnknownStageStateError,
     derive_run_status_from_stages,
     is_terminal_run_status,
+    is_terminal_stage_status,
     normalize_stage_state,
     run_requires_review,
     validate_run_transition,
@@ -64,6 +65,9 @@ def test_run_state_transitions_reject_unknown_or_terminal_reopen_paths():
     with pytest.raises(InvalidStateTransitionError, match="completed"):
         validate_run_transition("completed", "running")
 
+    with pytest.raises(InvalidStateTransitionError, match="running"):
+        validate_run_transition("running", "queued")
+
     with pytest.raises(UnknownRunStateError, match="mystery"):
         validate_run_transition("mystery", "running")
 
@@ -105,6 +109,49 @@ def test_stage_status_snapshot_normalizes_current_run_stage_records():
     assert from_mapping.status == "completed"
 
 
+def test_stage_status_snapshot_rejects_unknown_stage_key():
+    with pytest.raises(UnknownStageStateError, match="unknown_stage"):
+        StageStateSnapshot("unknown_stage", "completed")
+
+
+def test_terminal_stage_status_helper_identifies_terminal_values():
+    assert is_terminal_stage_status("completed") is True
+    assert is_terminal_stage_status("degraded") is True
+    assert is_terminal_stage_status("failed") is True
+    assert is_terminal_stage_status("skipped") is True
+    assert is_terminal_stage_status("not_started") is False
+    assert is_terminal_stage_status("in_progress") is False
+
+
+def test_terminal_stage_status_helper_rejects_unknown_status():
+    with pytest.raises(UnknownStageStateError, match="mystery"):
+        is_terminal_stage_status("mystery")
+
+
+def test_derive_run_status_reports_queued_for_empty_stage_list():
+    assert derive_run_status_from_stages([]) == "queued"
+
+
+def test_derive_run_status_reports_failed_for_failed_intake_validation():
+    stages = [
+        StageStateSnapshot("intake_validation", "failed", review_required=True),
+        StageStateSnapshot("research_plan", "not_started"),
+        StageStateSnapshot("weather", "not_started"),
+    ]
+
+    assert derive_run_status_from_stages(stages) == "failed"
+
+
+def test_derive_run_status_reports_failed_for_failed_research_plan():
+    stages = [
+        StageStateSnapshot("intake_validation", "completed"),
+        StageStateSnapshot("research_plan", "failed", review_required=True),
+        StageStateSnapshot("weather", "not_started"),
+    ]
+
+    assert derive_run_status_from_stages(stages) == "failed"
+
+
 def test_derive_run_status_reports_partial_success_for_failed_stage_with_usable_output():
     stages = [
         StageStateSnapshot("intake_validation", "completed"),
@@ -117,6 +164,35 @@ def test_derive_run_status_reports_partial_success_for_failed_stage_with_usable_
 
     assert derive_run_status_from_stages(stages) == "partial_success"
     assert run_requires_review(stages) is True
+
+
+def test_derive_run_status_reports_partial_success_for_failed_memo_assembly_with_outputs():
+    stages = [
+        StageStateSnapshot("intake_validation", "completed"),
+        StageStateSnapshot("research_plan", "completed"),
+        StageStateSnapshot("weather", "completed"),
+        StageStateSnapshot("carrier", "completed"),
+        StageStateSnapshot("caselaw", "completed"),
+        StageStateSnapshot("citation_verify", "completed"),
+        StageStateSnapshot("memo_assembly", "failed", review_required=True),
+    ]
+
+    assert derive_run_status_from_stages(stages) == "partial_success"
+
+
+def test_derive_run_status_reports_partial_success_for_failed_export_with_outputs():
+    stages = [
+        StageStateSnapshot("intake_validation", "completed"),
+        StageStateSnapshot("research_plan", "completed"),
+        StageStateSnapshot("weather", "completed"),
+        StageStateSnapshot("carrier", "completed"),
+        StageStateSnapshot("caselaw", "completed"),
+        StageStateSnapshot("citation_verify", "completed"),
+        StageStateSnapshot("memo_assembly", "completed"),
+        StageStateSnapshot("export", "failed", review_required=True),
+    ]
+
+    assert derive_run_status_from_stages(stages) == "partial_success"
 
 
 def test_derive_run_status_reports_failed_when_no_reviewable_output_survives():


### PR DESCRIPTION
## Summary

Adds focused regression coverage for the orchestration run-state contract branch paths identified after PR #70. This is intentionally test-only: no orchestration behavior, runtime surface, fixtures, cache samples, notebooks, or docs were changed.

Closes #71.

## Branch paths covered

- failed `intake_validation` -> `failed`
- failed `research_plan` -> `failed`
- failed `memo_assembly` with usable outputs -> `partial_success`
- failed `export` with usable outputs -> `partial_success`
- empty stage list -> `queued`
- invalid `StageStateSnapshot` stage key -> `UnknownStageStateError`
- invalid run transition `running` -> `queued` -> `InvalidStateTransitionError`
- direct `is_terminal_stage_status(...)` assertions for terminal and nonterminal statuses

## Optional cleanup decision

- Did not add package-level exports for `BLOCKING_STAGE_KEYS`, `RunStatus`, `StageKey`, or `StageStatus`; keeping this PR as a direct regression-test follow-up avoids expanding the public API surface beyond PR #70.

## Validation

- `python -m pytest tests/test_orchestration_state.py -q` -> `19 passed`
- `python -m pytest -q` -> `390 passed`
- `git diff --check` -> passed