### PR TITLE
Add Issue 11 run-status UX spec

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -34,6 +34,7 @@ This is research acceleration, not legal advice.
 | Evidence schema spec (`#24`) | Complete and closed as the written source of truth in `docs/V2_EVIDENCE_SCHEMA.md` |
 | Quality rubric (`#27`) | First-pass rubric plus local and CI artifact workflows landed in `docs/V2_RELEASE_RUBRIC.md`; demo-ready threshold calibration, blocking/advisory metric categories, live preflight evidence, run-scoped verify artifacts, verify manifests, and a stable latest pointer are now explicit, while broader CI and pilot operationalization remain open |
 | Orchestration API (`#10`) | First narrow run-state contract slice is implemented in `src/war_room/orchestration.py` and documented in `docs/ISSUE_10_RUN_STATE_CONTRACT.md`; issue `#73` adds typed start-run and get-run-status API boundary contracts in `src/war_room/orchestration_api_contracts.py` and `docs/ISSUE_10_API_CONTRACTS.md`; the first in-process offline service slice is implemented in `src/war_room/orchestration_service.py` and documented in `docs/ISSUE_10_SERVICE_SLICE.md`; the operator-facing status presentation layer is implemented in `src/war_room/orchestration_status_view.py` and documented in `docs/ISSUE_10_STATUS_PRESENTATION.md`; issue `#78` adds the dependency-free thin transport/request-handler wrapper in `src/war_room/orchestration_transport.py` and `docs/ISSUE_78_THIN_TRANSPORT_WRAPPER.md`; the dev-only standard-library HTTP adapter lives in `src/war_room/orchestration_http.py` and `docs/ISSUE_10_DEV_HTTP_WRAPPER.md`; production API routing, queues, persistence, retries, circuit breakers, auth, dashboards, and UI remain future work |
+| Run-status UX spec (`#11`) | First narrow run-status UX/spec slice is documented in `docs/ISSUE_11_RUN_STATUS_UX_SPEC.md`; future user-facing status screens should consume the existing transport/HTTP `status_presentation` payload and must not infer operator status independently when the presentation payload already provides it; guided web intake, frontend implementation, dashboards, auth, persistence, and production API work remain future work |
 | Cache samples | Milton/Citizens/Pinellas + Ian/Citizens/Lee + TX hail/Allstate/Tarrant + TX hail matching/Allstate Texas Lloyds/Tarrant DP-3 + Ida/Lloyd's/Orleans committed |
 
 ## 3) What changed recently
@@ -80,6 +81,7 @@ This is research acceleration, not legal advice.
 - The run-status presentation layer now derives operator-facing status, review reasons, degraded/failed stage summaries, usable-output availability, and next actions from the typed service response without adding UI or transport.
 - The thin orchestration transport wrapper now returns JSON-safe dependency-free handler payloads with `ok`, `operation`, typed `payload`, and `status_presentation`; invalid requests and unknown run IDs are transport errors, while accepted offline scenario failures remain `ok=true` typed failed run-status responses.
 - The dev-only standard-library HTTP adapter now exposes `GET /healthz`, `POST /runs`, `POST /runs/{run_id}/execute`, and `GET /runs/{run_id}` over the existing transport handlers for local future-app probes while preserving process-local in-memory service state and the transport JSON envelope.
+- The first issue `#11` run-status UX/spec slice now explains how a future user-facing status screen should present `operator_status`, headline/message, stage progress, usable outputs, review-required reasons, degraded/failed stages, next actions, and collapsed technical details from the existing status presentation and typed transport payloads without building a frontend app.
 - The notebook Evidence Board now has a styled HTML review surface over the existing typed read model, while the plain text formatter remains available as a fallback.
 
 ## 4) Quick run
@@ -106,6 +108,7 @@ Core implementation lives in `src/war_room/`.
 ## 6) Known limitations
 
 - Notebook UX is useful for demos but not ideal for non-technical users.
+- Issue `#11` now has a run-status UX/spec slice, but guided web intake and the actual product UI remain unbuilt.
 - Case law relevance and authority summarization still need stricter filtering/ranking in edge cases.
 - Five public/redacted fact patterns are pre-seeded in cache samples, all five are registry-backed for cache-only notebook use, and issue `#8` is closed as completed. Additional Florida fixture seeding is no longer part of `#8` and should be explicitly scoped as follow-up work if maintainers want it.
 - Export output quality is materially cleaner than earlier notebook-era baselines, but it is not yet polished for repeated client-facing use across broader fixture coverage.
@@ -138,6 +141,7 @@ Core implementation lives in `src/war_room/`.
 - [FIXTURE_SEEDING.md](FIXTURE_SEEDING.md): safe process for adding or promoting offline fixture scenarios under the completed `#8` pattern or a future fixture follow-up
 - [ISSUE_8_READINESS_AUDIT.md](ISSUE_8_READINESS_AUDIT.md): `#8` readiness/closure audit after the fifth fixture lane and five-lane baseline validation
 - [ISSUE_10_DEV_HTTP_WRAPPER.md](ISSUE_10_DEV_HTTP_WRAPPER.md): dev-only standard-library HTTP adapter over the existing orchestration transport layer
+- [ISSUE_11_RUN_STATUS_UX_SPEC.md](ISSUE_11_RUN_STATUS_UX_SPEC.md): narrow issue `#11` run-status UX/spec slice over the existing `status_presentation` payload
 - [ROADMAP.md](ROADMAP.md): plain-language roadmap and active execution order
 - [V2_WORKFLOW_IA.md](V2_WORKFLOW_IA.md): canonical V2 workflow, IA, and design-system rules
 - [V2_EVIDENCE_SCHEMA.md](V2_EVIDENCE_SCHEMA.md): canonical V2 evidence graph, audit schema, and versioning rules

--- a/docs/ISSUE_10_STATUS_PRESENTATION.md
+++ b/docs/ISSUE_10_STATUS_PRESENTATION.md
@@ -73,6 +73,13 @@ thin dependency-free request-handler wrapper in
 includes this presentation payload in start, execute, and status responses
 without adding HTTP routes or a web framework.
 
+## UX Follow-Up
+
+Issue `#11` now has a narrow run-status UX/spec slice in
+[`ISSUE_11_RUN_STATUS_UX_SPEC.md`](ISSUE_11_RUN_STATUS_UX_SPEC.md). That
+document explains how a future user-facing status screen should consume this
+`status_presentation` payload without adding a frontend app in this repo.
+
 ## Intentionally Not Included
 
 - no web app

--- a/docs/ISSUE_10_STATUS_PRESENTATION.md
+++ b/docs/ISSUE_10_STATUS_PRESENTATION.md
@@ -13,8 +13,9 @@ HTTP routes, a web framework, persistence, queues, auth, or UI.
 - The view keeps the canonical run `status` and adds `operator_status`,
   `headline`, `operator_message`, usable-output availability, review reasons,
   degraded stages, failed stages, typed failure details, and next actions.
-- The smoke CLI now includes those operator-facing fields while preserving the
-  existing machine-readable status, stage summary, and usable-output summary.
+- The smoke CLI now includes those operator-facing fields while preserving
+  local dev convenience summaries for stage status and usable outputs. Those
+  smoke summaries are not transport or HTTP envelope fields.
 
 ## Status Meanings
 

--- a/docs/ISSUE_11_RUN_STATUS_UX_SPEC.md
+++ b/docs/ISSUE_11_RUN_STATUS_UX_SPEC.md
@@ -1,0 +1,202 @@
+# Issue 11 Run-Status UX Spec
+
+Last updated: May 16, 2026
+
+This document defines a narrow product-facing run-status screen spec for issue
+`#11`. It explains how a future user-facing surface should consume and present
+the existing orchestration `status_presentation` payload without building a
+frontend app in this repo.
+
+This is a UX/spec/read-model slice only. It does not add React, Next.js, a
+dashboard, auth, persistence, a production API, notebook changes, dependencies,
+fixtures, cache changes, citation changes, or live retrieval changes.
+
+## Purpose
+
+The run-status screen answers five user questions:
+
+- Has the run been accepted, started, completed, degraded, partially completed,
+  or failed?
+- Are any outputs usable for human review?
+- Which stages need attention?
+- What should the operator do next?
+- What technical detail is available if a builder needs to troubleshoot?
+
+The screen is a transition surface, not the final destination. When usable
+outputs exist, it should route the user toward Evidence Review, Issue
+Workspace, Memo Composer, or Export surfaces as appropriate. It must preserve
+the repo's demo and legal-review posture: outputs are research acceleration
+materials, not legal advice, and citations must be independently verified
+before reliance.
+
+## User Types
+
+### Attorney or Reviewer
+
+Needs a concise trust posture before reading or relying on output. The screen
+must make review-required, degraded, partial-success, and failed states visible
+without requiring the reviewer to inspect raw logs.
+
+### Paralegal or Operator
+
+Owns day-to-day run monitoring. The screen must show the current operator
+status, stage progress, usable outputs, review reasons, and next actions in
+plain English.
+
+### Technical Builder or Demo Operator
+
+Needs the same operator view plus enough collapsed technical detail to validate
+the transport payload, run ID, scenario ID, canonical status, failed-stage
+details, and typed error payloads during demos or local development.
+
+## Authoritative Data Contract
+
+A future UI should consume the transport or dev-HTTP envelope:
+
+- `ok`
+- `operation`
+- `payload`
+- `status_presentation`
+
+For successful orchestration responses, `status_presentation` is the
+authoritative user-facing read model. The UI should use its `operator_status`,
+`headline`, `operator_message`, `review_reasons`, `degraded_stages`,
+`failed_stages`, `usable_outputs`, and `next_actions` instead of independently
+deriving run meaning.
+
+The typed `payload` remains the source for canonical machine detail:
+
+- `payload.run.status`
+- `payload.run.review_required`
+- `payload.status.stage_counts`
+- `payload.timeline.stages`
+- `payload.usable_outputs`
+- `payload.failure`
+
+If a dev smoke summary provides convenience fields such as `stage_summary` or
+`usable_output_summary`, the screen may render those directly. When consuming
+the transport or HTTP envelope, the screen should build the stage progress list
+from `payload.timeline.stages` and the usable-output list from
+`status_presentation.usable_outputs` or `payload.usable_outputs`, while keeping
+`status_presentation.operator_status` authoritative.
+
+For `ok=false` transport responses, `status_presentation` is `null`. The UI
+should present the typed `payload.error` as a request or lookup problem, not as
+an accepted run's product status unless the accepted run payload itself reports
+`payload.run.status="failed"`.
+
+## Primary Status States
+
+| Operator status | User-facing meaning | Presentation rule |
+|---|---|---|
+| `queued` | The run was accepted but has not started. | Show a neutral waiting state and avoid implying work has begun. |
+| `running` | The run is in progress. | Show stage progress and tell the operator to check again before relying on outputs. |
+| `completed` | The run completed with usable outputs and no surfaced review/degraded operator condition. | Show outputs, next actions, and standard legal/demo verification reminders. |
+| `degraded` | The canonical run may be complete, but one or more stages reported limitations. | Treat as operator-facing review required; show degraded stages and reasons prominently. |
+| `review_required` | Outputs are usable, but the run or output contract says human review is required. | Mark outputs as usable but not clean final support. |
+| `partial_success` | The run did not fully complete, but at least one usable output survived. | Clearly distinguish surviving usable outputs from failed stages; never call it complete. |
+| `failed` | The run did not produce a reviewable bundle. | Block demo-ready language and direct the operator to failure details and rerun steps. |
+
+## Field Presentation
+
+### Top Summary Card
+
+- `operator_status`: primary badge and state label.
+- `headline`: main status sentence.
+- `operator_message`: plain-English explanation beneath the headline.
+- `run_id` and `scenario_id`: visible as secondary metadata.
+- `payload.run.status`: available in technical details when it differs from
+  `operator_status`; do not make the user reconcile both statuses in the main
+  summary.
+
+### Stage Progress List
+
+- Render every stage from `stage_summary` when present, otherwise from
+  `payload.timeline.stages`.
+- Show stage key, status, short summary, and review-required marker.
+- Elevate stages listed in `degraded_stages` and `failed_stages`.
+- Do not hide degraded, skipped, or failed stages in logs.
+
+### Usable Outputs Section
+
+- Render `usable_output_summary` when present, otherwise render
+  `status_presentation.usable_outputs`.
+- Show output label, output type, stage key, URI when available, and
+  `review_required`.
+- Label review-required outputs as usable for review, not verified final
+  support.
+
+### Review-Required Section
+
+- Show `review_reasons` as primary operator-facing reasons.
+- Include `degraded_stages` and `failed_stages` as concrete anchors.
+- If there are no reasons but `review_required=true`, display the generic
+  contract reason from the presentation payload.
+
+### Next Actions Section
+
+- Render `next_actions` as the operator checklist.
+- For `failed`, use blocking language such as "Do not present this run as
+  demo-ready."
+- For `degraded`, `review_required`, and `partial_success`, make inspection and
+  citation/disclaimer review the next action before any external-facing demo.
+
+### Technical Details
+
+- Collapsed by default.
+- Include canonical `payload.run.status`, `payload.status.stage_counts`,
+  `payload.failure`, stage failure payloads, transport `operation`, and `ok`.
+- Keep raw JSON available for a builder/demo operator, not as the primary
+  attorney/paralegal reading surface.
+
+## Copy Rules
+
+- Use plain English and stable state labels.
+- Do not claim legal sufficiency, citation verification, or final readiness.
+- Do not describe a `degraded`, `review_required`, or `partial_success` run as
+  fully clean.
+- Clearly mark review-required outputs in the main flow and output list.
+- Clearly distinguish usable-but-needs-review from failed.
+- Preserve the repo's demo, not-legal-advice, and verify-all-citations
+  disclaimers.
+- Prefer "usable for human review" over "approved", "verified", or "ready".
+- Use stage names from the payload; do not invent new product-stage names that
+  conflict with the orchestration contract.
+
+## Layout and IA Guidance
+
+1. Top summary card.
+2. Stage progress list.
+3. Usable outputs section.
+4. Review-required section.
+5. Next actions section.
+6. Technical details collapsed by default.
+
+The screen should stay consistent with `docs/V2_WORKFLOW_IA.md`: Run Status is
+a timeline and trust-posture view that hands users into evidence and review
+surfaces. It should not become a generic dashboard or the final product
+destination.
+
+## Non-Goals
+
+- No frontend implementation.
+- No React, Next.js, dashboard, or app framework.
+- No auth, sessions, users, or access-control model.
+- No persistence, database, queue, worker, retry policy, or circuit breaker.
+- No production API.
+- No new dependencies.
+- No notebook changes.
+- No fixture, cache, citation, prompt, schema, or live retrieval changes.
+
+## Acceptance Check
+
+This spec is sufficient for the current slice when:
+
+- a future UI builder can identify `status_presentation` as the primary
+  product-facing read model,
+- the screen behavior for queued, running, completed, degraded,
+  review-required, partial-success, and failed runs is explicit,
+- usable outputs are distinguished from failed or unreviewed outputs,
+- review-required language is prominent and preserves disclaimers,
+- technical details remain available but secondary,
+- and the repo still has no frontend implementation or expanded runtime scope.

--- a/docs/ISSUE_11_RUN_STATUS_UX_SPEC.md
+++ b/docs/ISSUE_11_RUN_STATUS_UX_SPEC.md
@@ -16,7 +16,7 @@ fixtures, cache changes, citation changes, or live retrieval changes.
 The run-status screen answers five user questions:
 
 - Has the run been accepted, started, completed, degraded, partially completed,
-  or failed?
+  failed, or cancelled?
 - Are any outputs usable for human review?
 - Which stages need attention?
 - What should the operator do next?
@@ -74,11 +74,14 @@ The typed `payload` remains the source for canonical machine detail:
 - `payload.failure`
 
 If a dev smoke summary provides convenience fields such as `stage_summary` or
-`usable_output_summary`, the screen may render those directly. When consuming
-the transport or HTTP envelope, the screen should build the stage progress list
-from `payload.timeline.stages` and the usable-output list from
-`status_presentation.usable_outputs` or `payload.usable_outputs`, while keeping
-`status_presentation.operator_status` authoritative.
+`usable_output_summary`, treat them as local smoke CLI conveniences only. They
+are not transport or HTTP envelope fields, and a future UI should not treat them
+as canonical product contract fields. When consuming the transport or HTTP
+envelope, build the stage progress list from `payload.timeline.stages` and the
+usable-output list from `status_presentation.usable_outputs`, while keeping the
+full `status_presentation` payload as the authoritative product-facing read
+model. Use `payload.usable_outputs` as typed technical detail, not as the
+default product-facing list when the presentation payload is present.
 
 For `ok=false` transport responses, `status_presentation` is `null`. The UI
 should present the typed `payload.error` as a request or lookup problem, not as
@@ -96,6 +99,7 @@ an accepted run's product status unless the accepted run payload itself reports
 | `review_required` | Outputs are usable, but the run or output contract says human review is required. | Mark outputs as usable but not clean final support. |
 | `partial_success` | The run did not fully complete, but at least one usable output survived. | Clearly distinguish surviving usable outputs from failed stages; never call it complete. |
 | `failed` | The run did not produce a reviewable bundle. | Block demo-ready language and direct the operator to failure details and rerun steps. |
+| `cancelled` | The run was stopped after acceptance before reaching a completed, partial-success, or failed terminal state. | Show a neutral terminal stopped state, do not present the run as demo-ready, and direct the operator to start a fresh run or inspect technical details. |
 
 ## Field Presentation
 
@@ -111,16 +115,21 @@ an accepted run's product status unless the accepted run payload itself reports
 
 ### Stage Progress List
 
-- Render every stage from `stage_summary` when present, otherwise from
-  `payload.timeline.stages`.
-- Show stage key, status, short summary, and review-required marker.
+- Render every stage from `payload.timeline.stages`.
+- Do not use dev smoke CLI `stage_summary` as the default UI source. It is only
+  a flat `{stage_key: status}` convenience summary and does not carry stage
+  `summary`, `error_summary`, or `review_required` detail.
+- Show stage key, status, short summary, error summary when present, and
+  review-required marker.
 - Elevate stages listed in `degraded_stages` and `failed_stages`.
 - Do not hide degraded, skipped, or failed stages in logs.
 
 ### Usable Outputs Section
 
-- Render `usable_output_summary` when present, otherwise render
-  `status_presentation.usable_outputs`.
+- Render `status_presentation.usable_outputs` as the default product-facing
+  output list.
+- Do not use dev smoke CLI `usable_output_summary` as the default UI source. It
+  is a compact smoke convenience view, not a transport or HTTP envelope field.
 - Show output label, output type, stage key, URI when available, and
   `review_required`.
 - Label review-required outputs as usable for review, not verified final
@@ -138,6 +147,9 @@ an accepted run's product status unless the accepted run payload itself reports
 - Render `next_actions` as the operator checklist.
 - For `failed`, use blocking language such as "Do not present this run as
   demo-ready."
+- For `cancelled`, use neutral stopped-run language and direct the operator to
+  start a fresh run or inspect technical details before attempting another demo
+  path.
 - For `degraded`, `review_required`, and `partial_success`, make inspection and
   citation/disclaimer review the next action before any external-facing demo.
 
@@ -162,6 +174,9 @@ an accepted run's product status unless the accepted run payload itself reports
 - Prefer "usable for human review" over "approved", "verified", or "ready".
 - Use stage names from the payload; do not invent new product-stage names that
   conflict with the orchestration contract.
+- Do not infer UI contract meaning from smoke CLI `stage_summary` or
+  `usable_output_summary`; those summaries are convenience output for local dev
+  smoke checks only.
 
 ## Layout and IA Guidance
 
@@ -195,7 +210,7 @@ This spec is sufficient for the current slice when:
 - a future UI builder can identify `status_presentation` as the primary
   product-facing read model,
 - the screen behavior for queued, running, completed, degraded,
-  review-required, partial-success, and failed runs is explicit,
+  review-required, partial-success, failed, and cancelled runs is explicit,
 - usable outputs are distinguished from failed or unreviewed outputs,
 - review-required language is prominent and preserves disclaimers,
 - technical details remain available but secondary,

--- a/docs/ISSUE_78_THIN_TRANSPORT_WRAPPER.md
+++ b/docs/ISSUE_78_THIN_TRANSPORT_WRAPPER.md
@@ -9,6 +9,11 @@ The wrapper proves that a future app can start an offline orchestration run,
 execute it synchronously, and retrieve status through JSON-safe request-handler
 functions. It does not add a production HTTP API.
 
+The companion issue `#11` run-status UX/spec note lives in
+[`ISSUE_11_RUN_STATUS_UX_SPEC.md`](ISSUE_11_RUN_STATUS_UX_SPEC.md). It treats
+the `status_presentation` field in this envelope as the authoritative
+operator-facing read model for a future UI.
+
 ## Scope Landed
 
 - `src/war_room/orchestration_transport.py` adds dependency-free handlers:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,6 +23,7 @@ This is the short version. Clean, practical, no drama.
 - The Export History read model now has the same typed `v2alpha1` contract path for export artifact rows, delivery state, disclaimer state, and audit references.
 - The Run Timeline read model now has a typed `v2alpha1` envelope over canonical `Run` and `RunStage` records.
 - A first narrow `#10` orchestration slice now defines shared run states, stage statuses, transition validation, and stage-to-run rollup helpers in `src/war_room/orchestration.py`; issue `#73` adds typed start-run and get-run-status API boundary contracts in `src/war_room/orchestration_api_contracts.py`; the first in-process offline service slice now lives in `src/war_room/orchestration_service.py`; the operator-facing status presentation layer lives in `src/war_room/orchestration_status_view.py`; issue `#78` adds a dependency-free thin transport/request-handler wrapper in `src/war_room/orchestration_transport.py`; the dev-only standard-library HTTP adapter lives in `src/war_room/orchestration_http.py`; production HTTP/API routing, persistence, queues, auth, dashboards, and UI remain future work.
+- A first narrow issue `#11` run-status UX/spec slice now lives in `docs/ISSUE_11_RUN_STATUS_UX_SPEC.md`; it defines how a future user-facing status screen should consume the existing `status_presentation` payload without adding a frontend app.
 - The committed five-scenario offline fixture lane now has a deterministic golden snapshot check for source mix, case counts, citation summaries, output structure, and coverage metadata.
 - The curated scenario registry now has five offline-ready fixture-backed benchmarks: Milton/Pinellas/Citizens, Ian/Lee/Citizens HO-3, Ida/Orleans/Lloyd's, Texas hail/Tarrant/Allstate HO-B, and Texas hail/Tarrant/Allstate DP-3.
 - The fixture-seeding process now defines when a scenario can be promoted to offline-ready status and tests guard against fixture-key or bundle drift.
@@ -37,13 +38,14 @@ This is the short version. Clean, practical, no drama.
 - Issue [#8](https://github.com/itprodirect/cat-loss-war-room/issues/8) is complete and closed. The five-lane offline fixture baseline now covers Milton, Ida, Ian/Lee/Citizens HO-3, Texas hail/Tarrant/Allstate HO-B, and Texas hail/Tarrant/Allstate DP-3 with registry-backed offline-ready scenarios and golden snapshot validation.
 - Issue [#9](https://github.com/itprodirect/cat-loss-war-room/issues/9) is complete. The closeout audit in [ISSUE_9_CLOSEOUT_AUDIT.md](ISSUE_9_CLOSEOUT_AUDIT.md) maps the expanded CI quality-gate requirements to workflow jobs, gate categories, tests, artifact evidence, and offline validation.
 - Issue [#10](https://github.com/itprodirect/cat-loss-war-room/issues/10) has a first run-state contract slice documented in [ISSUE_10_RUN_STATE_CONTRACT.md](ISSUE_10_RUN_STATE_CONTRACT.md), an issue `#73` API boundary contract slice documented in [ISSUE_10_API_CONTRACTS.md](ISSUE_10_API_CONTRACTS.md), a first in-process offline service slice documented in [ISSUE_10_SERVICE_SLICE.md](ISSUE_10_SERVICE_SLICE.md), an operator-facing status presentation layer documented in [ISSUE_10_STATUS_PRESENTATION.md](ISSUE_10_STATUS_PRESENTATION.md), an issue `#78` thin transport wrapper documented in [ISSUE_78_THIN_TRANSPORT_WRAPPER.md](ISSUE_78_THIN_TRANSPORT_WRAPPER.md), and a dev-only standard-library HTTP adapter documented in [ISSUE_10_DEV_HTTP_WRAPPER.md](ISSUE_10_DEV_HTTP_WRAPPER.md). Production HTTP/API routing, persistence, retries, and circuit-breaker behavior are still pending.
+- Issue [#11](https://github.com/itprodirect/cat-loss-war-room/issues/11) has a first run-status UX/spec slice documented in [ISSUE_11_RUN_STATUS_UX_SPEC.md](ISSUE_11_RUN_STATUS_UX_SPEC.md). Guided web intake, frontend implementation, dashboards, auth, persistence, and production API work remain pending.
 - Placeholder directories under `apps/`, `packages/`, and `workers/` are planned V2 boundaries only. The active runtime remains the notebook plus `src/war_room/`.
 
 ## Delivery layers
 
 - V0 implemented now: notebook-first demo, cache-backed offline lane, package bootstrap, and current memo pipeline.
 - V2 definition work completed: workflow/IA in `#23`, evidence schema in `#24`, repo/runtime boundary framing in `#22`, and a first-pass release rubric in `#27`.
-- V2 implementation work still pending: broaden CI and pilot operationalization from `#27`, then continue explicitly scoped product slices in `#10`/`#11` against the existing offline orchestration contracts.
+- V2 implementation work still pending: broaden CI and pilot operationalization from `#27`, then continue explicitly scoped product slices in `#10`/`#11` against the existing offline orchestration contracts and the first `#11` run-status UX spec.
 
 ## Active Priority Rank
 
@@ -73,7 +75,7 @@ Issues [#23](https://github.com/itprodirect/cat-loss-war-room/issues/23) and [#2
   - `#23` and `#24` should be treated as completed definition work; downstream implementation belongs elsewhere.
   - `#6` is complete and should stay scoped to closeout follow-through rather than new runtime work.
   - `#9` is complete for the current CI quality-gate acceptance criteria; future security, pilot, and optional fixture-breadth work belongs in `#18`, `#19`, `#27`, or a newly scoped follow-up rather than reopening `#8`.
-  - `#11` should explicitly implement the workflow defined in `#23`.
+  - `#11` now has a run-status UX/spec slice over the existing orchestration `status_presentation` payload; future implementation should still follow the workflow defined in `#23`.
   - `#12` should explicitly implement against the canonical schema defined in `#24`.
 - `#27` should now focus on CI and pilot operationalization of the calibrated rubric rather than inventing the first rubric draft.
   - CI artifact emission, local verify evidence bundles, artifact integrity checks, and dashboard-ready blocking/advisory scorecard categories already landed; the remaining work is broader gate coverage and pilot evidence.
@@ -126,3 +128,4 @@ Goal: trust, polish, and real-world adoption readiness.
 - Issue `#8` readiness and closure audit: [ISSUE_8_READINESS_AUDIT.md](ISSUE_8_READINESS_AUDIT.md)
 - Workflow and IA source of truth: [V2_WORKFLOW_IA.md](V2_WORKFLOW_IA.md)
 - Evidence schema source of truth: [V2_EVIDENCE_SCHEMA.md](V2_EVIDENCE_SCHEMA.md)
+- Run-status UX/spec source for issue `#11`: [ISSUE_11_RUN_STATUS_UX_SPEC.md](ISSUE_11_RUN_STATUS_UX_SPEC.md)

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2334,3 +2334,45 @@ Status: Complete
     -> passed; status `completed`, `operator_status=degraded`, and usable
     outputs were available.
   - `git diff --check` -> passed.
+
+## Session 118 - Issue 11 Run-Status UX Spec
+Date: 2026-05-16
+Status: Complete
+
+- Completed a narrow issue `#11` run-status UX/spec slice over the existing
+  orchestration status presentation payload without building a frontend app.
+- What changed:
+  - Added `docs/ISSUE_11_RUN_STATUS_UX_SPEC.md` defining the purpose, user
+    types, primary status states, field presentation rules, copy rules,
+    layout/IA guidance, data contract, and non-goals for a future run-status
+    screen.
+  - The spec makes `status_presentation.operator_status`, `headline`,
+    `operator_message`, `review_reasons`, degraded/failed stages, usable
+    outputs, and `next_actions` the authoritative product-facing read model.
+  - The spec clarifies that a future UI may render stage progress from
+    `payload.timeline.stages` or dev smoke `stage_summary`, but must not infer
+    operator status independently when `status_presentation` already provides
+    it.
+  - Cross-linked the spec from the issue `#10` status presentation note and the
+    issue `#78` thin transport wrapper note.
+  - Synced handoff, roadmap, heartbeat, and this session log to the new
+    documentation-only issue `#11` slice.
+- Decisions not added:
+  - no frontend implementation, React, Next.js, dashboard, auth, persistence,
+    production API, queues, workers, retries, circuit breakers, notebook
+    changes, dependencies, fixture/cache/citation changes, prompts, schemas,
+    golden snapshots, or live retrieval changes were added.
+  - no docs test was added because there is no existing lightweight
+    docs/reference validation pattern for this issue-note cross-link.
+- Validation:
+  - `python -m pytest -q` -> `430 passed in 16.30s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `430 passed in 20.73s`; verify manifest written under
+    `runs/verify/2026-05-16_feat-issue-11-run-status-ux-spec_20260516t211620z.json`.
+  - `python -m war_room.orchestration_service --smoke --scenario milton_pinellas_citizens_ho3`
+    -> passed; status `completed`, `operator_status=degraded`,
+    `usable_outputs_available=true`, review reasons were present, degraded
+    stages included `citation_verify` and `memo_assembly`, and usable output
+    summaries included weather, carrier, caselaw, citation verification, memo
+    draft, and audit bundle.
+  - `git diff --check` -> passed.

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -1,15 +1,15 @@
 # Heartbeat
 
 - Repo: `cat-loss-war-room`
-- Current milestone: Keep the notebook demo stable while landing the dev-only issue `#10` HTTP adapter over the existing transport layer; broader `#27` CI/pilot operationalization remains open.
-- Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`, not a full web app. The issue `#10` stack now has canonical run/stage vocabulary in `src/war_room/orchestration.py`, typed API boundary contracts in `src/war_room/orchestration_api_contracts.py`, an in-process offline service in `src/war_room/orchestration_service.py`, an operator-facing status presentation layer in `src/war_room/orchestration_status_view.py`, a dependency-free thin transport/request-handler wrapper in `src/war_room/orchestration_transport.py`, and a dev-only standard-library HTTP adapter in `src/war_room/orchestration_http.py`. #64 and #65 are closed hygiene follow-ups.
-- Current branch: `feat/issue-10-dev-http-wrapper`
-- Last validated: 2026-05-16 via `python -m pytest tests/test_orchestration_http.py tests/test_orchestration_transport.py tests/test_orchestration_service.py -q` (`19 passed in 3.19s`), `python -m pytest -q` (`430 passed in 14.29s`), `python -m war_room --verify` (`430 passed` inside verify; manifest `runs/verify/2026-05-16_feat-issue-10-dev-http-wrapper_20260516t204511z.json`), `python -m war_room.orchestration_service --smoke --scenario milton_pinellas_citizens_ho3` (`status=completed`, `operator_status=degraded`, usable outputs available), and `git diff --check`.
-- Current focus: Open the dev-only HTTP adapter PR without expanding into a production API or web app.
-- Hot files: `src/war_room/orchestration_http.py`, `tests/test_orchestration_http.py`, `docs/ISSUE_10_DEV_HTTP_WRAPPER.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/heartbeat.md`, `docs/SESSION_LOG.md`
-- Blockers: None for the dev-only HTTP adapter slice.
+- Current milestone: Keep the notebook demo stable while landing the narrow issue `#11` run-status UX/spec slice over the existing orchestration `status_presentation` payload; broader `#27` CI/pilot operationalization remains open.
+- Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`, not a full web app. The issue `#10` stack now has canonical run/stage vocabulary in `src/war_room/orchestration.py`, typed API boundary contracts in `src/war_room/orchestration_api_contracts.py`, an in-process offline service in `src/war_room/orchestration_service.py`, an operator-facing status presentation layer in `src/war_room/orchestration_status_view.py`, a dependency-free thin transport/request-handler wrapper in `src/war_room/orchestration_transport.py`, and a dev-only standard-library HTTP adapter in `src/war_room/orchestration_http.py`. The first issue `#11` run-status UX/spec slice now lives in `docs/ISSUE_11_RUN_STATUS_UX_SPEC.md` and remains documentation-only. #64 and #65 are closed hygiene follow-ups.
+- Current branch: `feat/issue-11-run-status-ux-spec`
+- Last validated: 2026-05-16 via `python -m pytest -q` (`430 passed in 16.30s`), `python -m war_room --verify` (`430 passed` inside verify; manifest `runs/verify/2026-05-16_feat-issue-11-run-status-ux-spec_20260516t211620z.json`), `python -m war_room.orchestration_service --smoke --scenario milton_pinellas_citizens_ho3` (`status=completed`, `operator_status=degraded`, usable outputs available), and `git diff --check`.
+- Current focus: Open the issue `#11` run-status UX/spec PR without expanding into a frontend app, dashboard, persistence, auth, or production API.
+- Hot files: `docs/ISSUE_11_RUN_STATUS_UX_SPEC.md`, `docs/ISSUE_10_STATUS_PRESENTATION.md`, `docs/ISSUE_78_THIN_TRANSPORT_WRAPPER.md`, `docs/HANDOFF.md`, `docs/ROADMAP.md`, `docs/heartbeat.md`, `docs/SESSION_LOG.md`
+- Blockers: None for the run-status UX/spec slice.
 - Do not touch this sprint: API framework, background queue, database, auth, dashboard, UI design, repo rename, broad product rewrites, placeholder V2 directories as live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
-- Latest session log: `docs/SESSION_LOG.md` session 117
-- Next best task: Review/open the dev-only HTTP adapter PR, then continue broader `#27` CI/pilot operationalization or scope the next explicit `#10`/`#11` slice without turning the repo into a full web app.
+- Latest session log: `docs/SESSION_LOG.md` session 118
+- Next best task: Review/open the issue `#11` run-status UX/spec PR, then continue broader `#27` CI/pilot operationalization or scope the next explicit `#11` guided-intake/status slice without turning the repo into a full web app.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.


### PR DESCRIPTION
Adds a narrow Issue #11 run-status UX/spec document defining how future product surfaces should present the existing orchestration status_presentation payload. Docs/spec only. No frontend, dashboard, auth, persistence, production API, dependencies, notebook, fixture, cache, citation, or live retrieval changes.