### PR TITLE
[codex] Add caselaw evidence adapter

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2708,8 +2708,9 @@ Status: Complete
 Date: 2026-05-20
 Status: Complete
 
-- Applied one focused PR `#95` follow-up to preserve previous case-law
-  primary-authority inference in `caselaw_pack_to_evidence_items(...)`.
+- Applied one focused PR `#95` follow-up that makes primary-authority
+  inference effective when `is_primary_authority` is absent, while preserving
+  explicit true/false values in `caselaw_pack_to_evidence_items(...)`.
 - What changed:
   - The adapter now treats an explicit case-row `is_primary_authority` value
     as authoritative and falls back to `score_url(...)` only when the field was

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2661,3 +2661,45 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `433 passed in 24.28s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-92-release-evidence-ci-reporting_20260520t042606z.json`.
+
+## Session 126 - Issue 94 Caselaw Evidence Adapter
+Date: 2026-05-20
+Status: Complete
+
+- Completed issue `#94` as the first narrow issue `#12` product-core
+  evidence/provenance adapter slice over current case-law module output.
+- What changed:
+  - Added `caselaw_pack_to_evidence_items(...)` in `src/war_room/models.py`
+    as a focused adapter seam from current `CaseLawPack` / `CaseIssue` /
+    `CaseEntry` data into canonical `EvidenceItem` records.
+  - Replaced positional case-law evidence IDs like `caselaw-case-1-1` with
+    deterministic IDs derived from stable case attributes and the existing
+    authority-key inputs, while preserving authority-key clustering behavior.
+  - Kept `RunAuditSnapshot` and Evidence Board construction on the existing
+    flow by routing only the case-law evidence-item mapping through the new
+    adapter.
+  - Added focused tests for repeated stable IDs, distinct case-row IDs,
+    case-law metadata preservation, audit-snapshot inclusion, evidence-board
+    rendering, and memo evidence-index output.
+- Decisions added:
+  - Case-law evidence IDs now use citation/name/court/year/URL/issue context
+    plus a short deterministic digest, with only deterministic collision
+    suffixing for duplicate stable IDs within one payload.
+- Decisions not added:
+  - no full issue `#12` evidence graph implementation, global evidence graph
+    rewrite, database, persistence, auth, users, sessions, queues, workers,
+    dashboard, frontend, API framework, production runtime, live retrieval
+    change, fixture/cache/citation provider change, AI scoring, ML dedupe,
+    broad title-similarity dedupe, readiness-level change, release claim,
+    pilot execution, firm memory, notebook behavior change, or docx/pdf export
+    pipeline was added.
+- Validation:
+  - `python -m pytest tests/test_models.py tests/test_evidence_board.py -q`
+    -> `24 passed in 0.43s`.
+  - `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q`
+    -> `52 passed in 2.19s`.
+  - `git diff --check` -> passed.
+  - `python -m pytest -q` -> `439 passed in 14.93s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `439 passed in 15.02s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-94-caselaw-evidence-adapter_20260520t055426z.json`.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2703,3 +2703,30 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `439 passed in 15.02s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-94-caselaw-evidence-adapter_20260520t055426z.json`.
+
+## Session 127 - PR 95 Primary-Authority Inference Follow-Up
+Date: 2026-05-20
+Status: Complete
+
+- Applied one focused PR `#95` follow-up to preserve previous case-law
+  primary-authority inference in `caselaw_pack_to_evidence_items(...)`.
+- What changed:
+  - The adapter now treats an explicit case-row `is_primary_authority` value
+    as authoritative and falls back to `score_url(...)` only when the field was
+    not provided on the case row.
+  - Added a focused regression test proving a case-law row without explicit
+    `is_primary_authority` can infer primary-authority status from a
+    CourtListener opinion URL, while an explicit `False` value still wins.
+- Decisions not added:
+  - no unrelated adapter refactor, source-scoring change, live retrieval,
+    fixture/cache/provider change, API/runtime work, persistence, frontend,
+    dashboard, AI scoring, readiness claim, or broad issue `#12` behavior was
+    added.
+- Validation:
+  - `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_export.py -q`
+    -> `36 passed in 1.82s`.
+  - `git diff --check` -> passed.
+  - `python -m pytest -q` -> `440 passed in 16.25s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `440 passed in 16.09s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-94-caselaw-evidence-adapter_20260520t061111z.json`.

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import re
 from typing import Any, Literal, Mapping, Sequence
 from urllib.parse import urlparse
@@ -1051,6 +1052,58 @@ def adapt_run_timeline(
     return RunTimelineReadModel.model_validate(payload)
 
 
+def caselaw_pack_to_evidence_items(
+    payload: Mapping[str, Any] | CaseLawPack,
+) -> list[EvidenceItem]:
+    """Adapt current case-law module output into canonical evidence items."""
+    caselaw = adapt_caselaw_pack(payload)
+    source_reasons = {
+        source.url: source.reason
+        for source in caselaw.sources
+        if source.url
+    }
+    evidence_items: list[EvidenceItem] = []
+    used_evidence_ids: dict[str, int] = {}
+
+    for issue in caselaw.issues:
+        for case in issue.cases:
+            source_profile = score_url(case.url, case.name)
+            normalized_citation = _normalize_citation_value(case.citation)
+            authority_key = _authority_key_from_parts(
+                citation=normalized_citation,
+                title=case.name,
+                court=case.court,
+                year=case.year,
+                url=case.url,
+            )
+            evidence_items.append(
+                EvidenceItem(
+                    evidence_id=_caselaw_evidence_id(
+                        issue_label=issue.issue,
+                        case=case,
+                        normalized_citation=normalized_citation,
+                        authority_key=authority_key,
+                        used_evidence_ids=used_evidence_ids,
+                    ),
+                    module="caselaw",
+                    evidence_type="case_authority",
+                    title=case.name,
+                    summary=case.one_liner,
+                    url=case.url,
+                    badge=case.badge,
+                    source_reason=source_reasons.get(case.url),
+                    source_class=case.source_class or source_profile.get("source_class"),
+                    source_tier=case.source_tier or source_profile.get("tier"),
+                    is_primary_authority=case.is_primary_authority,
+                    authority_key=authority_key,
+                    issue=issue.issue,
+                    citation=normalized_citation,
+                )
+            )
+
+    return evidence_items
+
+
 def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditSnapshot:
     """Build a canonical audit snapshot from normalized memo-render input."""
     weather_payload = weather_brief_to_payload(memo_input.weather)
@@ -1133,43 +1186,11 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
         )
         evidence_ids_by_module["carrier"].append(evidence_id)
 
-    caselaw_source_reasons = {
-        source.get("url"): source.get("reason")
-        for source in caselaw_payload.get("sources", [])
-        if source.get("url")
-    }
-    for issue_index, issue in enumerate(caselaw_payload.get("issues", []), 1):
-        for case_index, case in enumerate(issue.get("cases", []), 1):
-            evidence_id = f"caselaw-case-{issue_index}-{case_index}"
-            source_profile = score_url(case.get("url", ""), case.get("name", ""))
-            normalized_citation = _normalize_citation_value(case.get("citation"))
-            evidence_items.append(
-                EvidenceItem(
-                    evidence_id=evidence_id,
-                    module="caselaw",
-                    evidence_type="case_authority",
-                    title=case.get("name", ""),
-                    summary=case.get("one_liner", ""),
-                    url=case.get("url"),
-                    badge=case.get("badge", ""),
-                    source_reason=caselaw_source_reasons.get(case.get("url")),
-                    source_class=case.get("source_class") or source_profile.get("source_class"),
-                    source_tier=case.get("source_tier") or source_profile.get("tier"),
-                    is_primary_authority=bool(
-                        case.get("is_primary_authority", source_profile.get("is_primary_authority"))
-                    ),
-                    authority_key=_authority_key_from_parts(
-                        citation=normalized_citation,
-                        title=case.get("name"),
-                        court=case.get("court"),
-                        year=case.get("year"),
-                        url=case.get("url"),
-                    ),
-                    issue=issue.get("issue"),
-                    citation=normalized_citation,
-                )
-            )
-            evidence_ids_by_module["caselaw"].append(evidence_id)
+    caselaw_evidence_items = caselaw_pack_to_evidence_items(memo_input.caselaw)
+    evidence_items.extend(caselaw_evidence_items)
+    evidence_ids_by_module["caselaw"].extend(
+        item.evidence_id for item in caselaw_evidence_items
+    )
 
     for index, check in enumerate(citecheck_payload.get("checks", []), 1):
         evidence_id = f"citation-check-{index}"
@@ -1727,6 +1748,34 @@ def _normalize_authority_name(value: str | None) -> str:
         return ""
     normalized = re.sub(r"[^a-z0-9]+", " ", value.lower())
     return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _caselaw_evidence_id(
+    *,
+    issue_label: str,
+    case: CaseEntry,
+    normalized_citation: str | None,
+    authority_key: str | None,
+    used_evidence_ids: dict[str, int],
+) -> str:
+    identity_parts = [
+        authority_key or "",
+        normalized_citation or "",
+        _normalize_authority_name(case.name),
+        _normalize_authority_name(case.court),
+        str(case.year or "").strip().lower(),
+        _normalize_cluster_url(case.url),
+        _normalize_authority_name(issue_label),
+    ]
+    digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[:10]
+    display_token = _stable_token(normalized_citation or case.name or authority_key or case.url)
+    display_token = display_token[:48].rstrip("-") or "case"
+    base_id = f"caselaw-case-{display_token}-{digest}"
+    collision_count = used_evidence_ids.get(base_id, 0) + 1
+    used_evidence_ids[base_id] = collision_count
+    if collision_count == 1:
+        return base_id
+    return f"{base_id}-{collision_count}"
 
 
 def _cluster_key_for_item(item: EvidenceItem) -> tuple[str, str]:

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1094,7 +1094,10 @@ def caselaw_pack_to_evidence_items(
                     source_reason=source_reasons.get(case.url),
                     source_class=case.source_class or source_profile.get("source_class"),
                     source_tier=case.source_tier or source_profile.get("tier"),
-                    is_primary_authority=case.is_primary_authority,
+                    is_primary_authority=_case_is_primary_authority(
+                        case,
+                        source_profile,
+                    ),
                     authority_key=authority_key,
                     issue=issue.issue,
                     citation=normalized_citation,
@@ -1776,6 +1779,15 @@ def _caselaw_evidence_id(
     if collision_count == 1:
         return base_id
     return f"{base_id}-{collision_count}"
+
+
+def _case_is_primary_authority(
+    case: CaseEntry,
+    source_profile: Mapping[str, Any],
+) -> bool:
+    if "is_primary_authority" in case.model_fields_set:
+        return bool(case.is_primary_authority)
+    return bool(source_profile.get("is_primary_authority"))
 
 
 def _cluster_key_for_item(item: EvidenceItem) -> tuple[str, str]:

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1785,6 +1785,7 @@ def _case_is_primary_authority(
     case: CaseEntry,
     source_profile: Mapping[str, Any],
 ) -> bool:
+    # model_fields_set distinguishes explicit true/false from omission; dump/reload paths may mark defaults as set.
     if "is_primary_authority" in case.model_fields_set:
         return bool(case.is_primary_authority)
     return bool(source_profile.get("is_primary_authority"))

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -16,6 +16,7 @@ from war_room.models import (
     EvidenceBoardReadModel,
     QuerySpec,
     adapt_evidence_board,
+    caselaw_pack_to_evidence_items,
     evidence_board_to_payload,
     run_audit_snapshot_from_parts,
 )
@@ -145,6 +146,7 @@ def test_build_evidence_board_links_claims_and_review_events_to_clusters():
 
 def test_build_evidence_board_from_parts_matches_snapshot_builder():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_parts()
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
     from_parts = build_evidence_board_from_parts(
         intake,
@@ -168,10 +170,17 @@ def test_build_evidence_board_from_parts_matches_snapshot_builder():
     assert from_parts.total_clusters == from_snapshot.total_clusters
     assert from_parts.review_required_clusters == from_snapshot.review_required_clusters
     assert from_parts.cluster_cards[0].cluster_id == from_snapshot.cluster_cards[0].cluster_id
+    assert any(
+        preview.evidence_id == caselaw_evidence_id
+        for card in from_parts.cluster_cards
+        for preview in card.evidence_previews
+    )
 
 
 def test_evidence_board_payload_round_trips_with_schema_version():
-    board = build_evidence_board_from_parts(*_sample_parts())
+    parts = _sample_parts()
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(parts[3])[0].evidence_id
+    board = build_evidence_board_from_parts(*parts)
 
     payload = evidence_board_to_payload(board)
     restored = adapt_evidence_board(payload)
@@ -181,6 +190,7 @@ def test_evidence_board_payload_round_trips_with_schema_version():
     assert payload["schema_version"] == "v2alpha1"
     assert restored.cluster_cards[0].cluster_id == board.cluster_cards[0].cluster_id
     assert "EVIDENCE BOARD" in rendered
+    assert caselaw_evidence_id in rendered
 
 
 def test_evidence_board_contract_rejects_unexpected_nested_fields():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -338,7 +338,7 @@ def test_render_includes_canonical_evidence_index_rows():
 
     assert "weather-source-1" in md
     assert "carrier-document-1" in md
-    assert "caselaw-case-1-1" in md
+    assert "caselaw-case-123-so-3d-456-" in md
     assert "citation-check-1" in md
 
 

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -8,6 +8,7 @@ from war_room.models import (
     CaseIntake,
     QuerySpec,
     adapt_citation_verify_pack,
+    caselaw_pack_to_evidence_items,
     citation_verify_pack_to_payload,
     memo_render_input_from_parts,
     run_audit_snapshot_from_parts,
@@ -120,6 +121,65 @@ def _sample_payloads():
     return intake, weather, carrier, caselaw, citecheck, query_plan
 
 
+def test_caselaw_evidence_adapter_returns_stable_ids_for_repeated_payloads():
+    _, _, _, caselaw, _, _ = _sample_payloads()
+
+    first_ids = [item.evidence_id for item in caselaw_pack_to_evidence_items(caselaw)]
+    second_ids = [item.evidence_id for item in caselaw_pack_to_evidence_items(caselaw)]
+
+    assert first_ids == second_ids
+    assert first_ids[0].startswith("caselaw-case-123-so-3d-456-")
+    assert first_ids[0] != "caselaw-case-1-1"
+
+
+def test_caselaw_evidence_adapter_does_not_collapse_distinct_case_rows():
+    _, _, _, caselaw, _, _ = _sample_payloads()
+    caselaw["issues"][0]["cases"].append(
+        {
+            "name": "Roe v. Ins",
+            "citation": "123 So.3d 456",
+            "court": "Fla. App.",
+            "year": "2023",
+            "one_liner": "Same reporter cite, different authority row.",
+            "url": "https://example.com/roe-case",
+            "badge": "professional",
+        }
+    )
+
+    evidence_ids = [item.evidence_id for item in caselaw_pack_to_evidence_items(caselaw)]
+
+    assert len(evidence_ids) == 2
+    assert len(set(evidence_ids)) == 2
+
+
+def test_caselaw_evidence_adapter_preserves_case_metadata():
+    _, _, _, caselaw, _, _ = _sample_payloads()
+    caselaw["issues"][0]["cases"][0].update(
+        {
+            "badge": "official",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+        }
+    )
+
+    item = caselaw_pack_to_evidence_items(caselaw)[0]
+
+    assert item.module == "caselaw"
+    assert item.evidence_type == "case_authority"
+    assert item.title == "Doe v. Ins"
+    assert item.summary == "Coverage upheld"
+    assert item.url == "https://example.com/case"
+    assert item.badge == "official"
+    assert item.source_reason == "Professional source"
+    assert item.source_class == "court_opinion"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+    assert item.issue == "Coverage"
+    assert item.citation == "123 so. 3d 456"
+    assert item.authority_key == "citation:123 so. 3d 456"
+
+
 def test_citation_verify_pack_adapter_round_trip():
     _, _, _, _, citecheck, _ = _sample_payloads()
 
@@ -177,6 +237,7 @@ def test_memo_render_input_from_parts_accepts_mixed_shapes():
 
 def test_run_audit_snapshot_builds_canonical_entities():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
     snapshot = run_audit_snapshot_from_parts(
         intake,
@@ -207,9 +268,14 @@ def test_run_audit_snapshot_builds_canonical_entities():
     assert snapshot.export_artifact.section_ids[:3] == ["trust-snapshot", "case-intake", "weather-corroboration"]
     assert payload["schema_version"] == "v2alpha1"
     assert payload["evidence_items"][0]["evidence_id"] == "weather-source-1"
+    assert any(
+        item.evidence_id == caselaw_evidence_id and item.module == "caselaw"
+        for item in snapshot.evidence_items
+    )
     assert payload["evidence_clusters"][0]["cluster_id"] == "cluster-1"
     assert payload["evidence_clusters"][2]["cluster_type"] == "citation"
     assert snapshot.memo_claims[0].cluster_ids == ["cluster-1"]
+    assert caselaw_evidence_id in snapshot.memo_claims[2].evidence_ids
     assert snapshot.memo_claims[2].cluster_ids == ["cluster-3"]
     assert snapshot.quality_snapshot.source_class_counts["government_guidance"] == 1
     assert snapshot.quality_snapshot.grouped_evidence_count == 1

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -180,6 +180,32 @@ def test_caselaw_evidence_adapter_preserves_case_metadata():
     assert item.authority_key == "citation:123 so. 3d 456"
 
 
+def test_caselaw_evidence_adapter_infers_primary_authority_when_field_missing():
+    _, _, _, caselaw, _, _ = _sample_payloads()
+    case = caselaw["issues"][0]["cases"][0]
+    case.update(
+        {
+            "name": "Sebo v. American Home Assurance Co.",
+            "url": "https://www.courtlistener.com/opinion/12345/sebo-v-american-home/",
+            "badge": "official",
+        }
+    )
+
+    assert "is_primary_authority" not in case
+
+    item = caselaw_pack_to_evidence_items(caselaw)[0]
+
+    assert item.source_class == "court_opinion"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+
+    case["is_primary_authority"] = False
+
+    explicit_item = caselaw_pack_to_evidence_items(caselaw)[0]
+
+    assert explicit_item.is_primary_authority is False
+
+
 def test_citation_verify_pack_adapter_round_trip():
     _, _, _, _, citecheck, _ = _sample_payloads()
 


### PR DESCRIPTION
## Summary

Closes #94.

Adds one focused adapter seam for current case-law module output: `caselaw_pack_to_evidence_items(...)` converts existing `CaseLawPack` / `CaseIssue` / `CaseEntry` data into canonical `EvidenceItem` records used by the current `RunAuditSnapshot` and Evidence Board flow.

## What changed

- Extracted the inline case-law `EvidenceItem` mapping from `run_audit_snapshot_from_memo_input` into a dedicated adapter helper in `src/war_room/models.py`.
- Replaced positional case-law IDs like `caselaw-case-1-1` with deterministic IDs derived from stable case attributes and existing authority-key inputs.
- Preserved citation, URL, source tier/class, primary-authority flag, issue label, title, summary, badge, source reason, and authority-key clustering behavior.
- Added focused tests for stable repeated IDs, distinct case-row IDs, metadata preservation, audit snapshot compatibility, Evidence Board rendering, and memo evidence-index output.
- Logged the build session in `docs/SESSION_LOG.md`.

## Non-goals kept out

No full #12 implementation, global evidence graph rewrite, database, persistence, auth, queues/workers, dashboard/frontend, API framework, live retrieval changes, fixture/provider changes, AI scoring, ML dedupe, readiness-level changes, release claim changes, pilot execution, firm memory, or docx/pdf export pipeline.

## Validation

- `python -m pytest tests/test_models.py tests/test_evidence_board.py -q` -> `24 passed in 0.43s`
- `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q` -> `52 passed in 2.19s`
- `git diff --check` -> passed
- `python -m pytest -q` -> `440 passed in 12.30s`
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `440 passed in 11.72s`