### PR TITLE
[codex] Add carrier evidence adapter

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2731,3 +2731,50 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `440 passed in 16.09s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-94-caselaw-evidence-adapter_20260520t061111z.json`.
+
+## Session 128 - Issue 96 Carrier Evidence Adapter
+Date: 2026-05-20
+Status: Complete
+
+- Completed issue `#96` as the carrier counterpart to the narrow issue `#12`
+  evidence/provenance adapter slice from issue `#94`.
+- What changed:
+  - Added `carrier_doc_pack_to_evidence_items(...)` in
+    `src/war_room/models.py` as a focused adapter seam from current
+    `CarrierDocPack` / `CarrierDocument` data into canonical `EvidenceItem`
+    records.
+  - Replaced positional carrier evidence IDs like `carrier-document-1` with
+    deterministic IDs derived from stable document attributes, the current
+    authority-key inputs, and carrier snapshot context.
+  - Kept `RunAuditSnapshot`, memo claims, evidence clusters, quality snapshot,
+    export rendering, and Evidence Board construction on the existing flow by
+    routing only the carrier evidence-item mapping through the new adapter.
+  - Added focused tests for repeated stable carrier IDs, distinct carrier-row
+    IDs, metadata preservation, audit-snapshot inclusion, evidence-board
+    rendering, memo evidence-index output, and explicit-vs-inferred
+    primary-authority behavior.
+- Decisions added:
+  - Carrier evidence IDs now use document type/title/URL, authority key, and
+    carrier snapshot context plus a short deterministic digest, with only
+    deterministic collision suffixing for duplicate stable IDs within one
+    payload.
+  - Carrier document rows can carry optional explicit `source_class`,
+    `source_tier`, and `is_primary_authority` fields; explicit
+    `is_primary_authority` true/false values win, while omitted values still
+    infer from `score_url(...)`.
+- Decisions not added:
+  - no full issue `#12` evidence graph implementation, global evidence graph
+    rewrite, database, persistence, auth, users, sessions, queues, workers,
+    dashboard, frontend, API framework, production runtime, live retrieval
+    change, fixture/cache/citation provider change, AI scoring, ML dedupe,
+    broad title-similarity dedupe, readiness-level change, release claim,
+    pilot execution, firm memory, notebook behavior change, or docx/pdf export
+    pipeline was added.
+- Validation:
+  - `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q`
+    -> `57 passed in 2.55s`.
+  - `python -m pytest -q` -> `444 passed in 17.21s`.
+  - `git diff --check` -> passed.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `444 passed in 18.09s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-96-carrier-evidence-adapter_20260520t070016z.json`.

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -332,6 +332,9 @@ class CarrierDocument(BaseModel):
     url: str = Field(min_length=1)
     badge: str = Field(min_length=1)
     why_it_matters: str = Field(min_length=1)
+    source_class: str | None = None
+    source_tier: str | None = None
+    is_primary_authority: bool | None = None
 
 
 class CarrierDocPack(BaseModel):
@@ -1052,6 +1055,60 @@ def adapt_run_timeline(
     return RunTimelineReadModel.model_validate(payload)
 
 
+def carrier_doc_pack_to_evidence_items(
+    payload: Mapping[str, Any] | CarrierDocPack,
+) -> list[EvidenceItem]:
+    """Adapt current carrier module output into canonical evidence items."""
+    carrier = adapt_carrier_doc_pack(payload)
+    sources_by_url = {
+        source.url: source
+        for source in carrier.sources
+        if source.url
+    }
+    evidence_items: list[EvidenceItem] = []
+    used_evidence_ids: dict[str, int] = {}
+
+    for document in carrier.document_pack:
+        source_profile = score_url(document.url, document.title)
+        source = sources_by_url.get(document.url)
+        evidence_type = document.doc_type.lower().replace(" ", "_")
+        authority_key = _authority_key_from_parts(
+            url=document.url,
+            title=document.title,
+        )
+        evidence_items.append(
+            EvidenceItem(
+                evidence_id=_carrier_evidence_id(
+                    carrier_snapshot=carrier.carrier_snapshot,
+                    document=document,
+                    evidence_type=evidence_type,
+                    authority_key=authority_key,
+                    used_evidence_ids=used_evidence_ids,
+                ),
+                module="carrier",
+                evidence_type=evidence_type,
+                title=document.title,
+                summary=document.why_it_matters,
+                url=document.url,
+                badge=document.badge,
+                source_reason=source.reason if source else None,
+                source_class=(
+                    document.source_class
+                    or (source.source_class if source else None)
+                    or source_profile.get("source_class")
+                ),
+                source_tier=document.source_tier or source_profile.get("tier"),
+                is_primary_authority=_carrier_document_is_primary_authority(
+                    document,
+                    source_profile,
+                ),
+                authority_key=authority_key,
+            )
+        )
+
+    return evidence_items
+
+
 def caselaw_pack_to_evidence_items(
     payload: Mapping[str, Any] | CaseLawPack,
 ) -> list[EvidenceItem]:
@@ -1160,34 +1217,11 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
         )
         evidence_ids_by_module["weather"].append(evidence_id)
 
-    carrier_source_reasons = {
-        source.get("url"): source.get("reason")
-        for source in carrier_payload.get("sources", [])
-        if source.get("url")
-    }
-    for index, document in enumerate(carrier_payload.get("document_pack", []), 1):
-        evidence_id = f"carrier-document-{index}"
-        source_profile = score_url(document.get("url", ""), document.get("title", ""))
-        evidence_items.append(
-            EvidenceItem(
-                evidence_id=evidence_id,
-                module="carrier",
-                evidence_type=document.get("doc_type", "carrier_document").lower().replace(" ", "_"),
-                title=document.get("title", ""),
-                summary=document.get("why_it_matters", ""),
-                url=document.get("url"),
-                badge=document.get("badge", ""),
-                source_reason=carrier_source_reasons.get(document.get("url")),
-                source_class=source_profile.get("source_class"),
-                source_tier=source_profile.get("tier"),
-                is_primary_authority=bool(source_profile.get("is_primary_authority")),
-                authority_key=_authority_key_from_parts(
-                    url=document.get("url"),
-                    title=document.get("title"),
-                ),
-            )
-        )
-        evidence_ids_by_module["carrier"].append(evidence_id)
+    carrier_evidence_items = carrier_doc_pack_to_evidence_items(memo_input.carrier)
+    evidence_items.extend(carrier_evidence_items)
+    evidence_ids_by_module["carrier"].extend(
+        item.evidence_id for item in carrier_evidence_items
+    )
 
     caselaw_evidence_items = caselaw_pack_to_evidence_items(memo_input.caselaw)
     evidence_items.extend(caselaw_evidence_items)
@@ -1751,6 +1785,45 @@ def _normalize_authority_name(value: str | None) -> str:
         return ""
     normalized = re.sub(r"[^a-z0-9]+", " ", value.lower())
     return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _carrier_evidence_id(
+    *,
+    carrier_snapshot: CarrierSnapshot,
+    document: CarrierDocument,
+    evidence_type: str,
+    authority_key: str | None,
+    used_evidence_ids: dict[str, int],
+) -> str:
+    identity_parts = [
+        authority_key or "",
+        evidence_type,
+        _normalize_authority_name(document.doc_type),
+        _normalize_authority_name(document.title),
+        _normalize_cluster_url(document.url),
+        _normalize_authority_name(carrier_snapshot.name),
+        _normalize_authority_name(carrier_snapshot.state),
+        _normalize_authority_name(carrier_snapshot.event),
+        _normalize_authority_name(carrier_snapshot.policy_type),
+    ]
+    digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[:10]
+    display_token = _stable_token(document.doc_type or document.title or authority_key or document.url)
+    display_token = display_token[:48].rstrip("-") or "document"
+    base_id = f"carrier-document-{display_token}-{digest}"
+    collision_count = used_evidence_ids.get(base_id, 0) + 1
+    used_evidence_ids[base_id] = collision_count
+    if collision_count == 1:
+        return base_id
+    return f"{base_id}-{collision_count}"
+
+
+def _carrier_document_is_primary_authority(
+    document: CarrierDocument,
+    source_profile: Mapping[str, Any],
+) -> bool:
+    if document.is_primary_authority is not None:
+        return bool(document.is_primary_authority)
+    return bool(source_profile.get("is_primary_authority"))
 
 
 def _caselaw_evidence_id(

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -16,6 +16,7 @@ from war_room.models import (
     EvidenceBoardReadModel,
     QuerySpec,
     adapt_evidence_board,
+    carrier_doc_pack_to_evidence_items,
     caselaw_pack_to_evidence_items,
     evidence_board_to_payload,
     run_audit_snapshot_from_parts,
@@ -146,6 +147,7 @@ def test_build_evidence_board_links_claims_and_review_events_to_clusters():
 
 def test_build_evidence_board_from_parts_matches_snapshot_builder():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_parts()
+    carrier_evidence_id = carrier_doc_pack_to_evidence_items(carrier)[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
     from_parts = build_evidence_board_from_parts(
@@ -171,6 +173,11 @@ def test_build_evidence_board_from_parts_matches_snapshot_builder():
     assert from_parts.review_required_clusters == from_snapshot.review_required_clusters
     assert from_parts.cluster_cards[0].cluster_id == from_snapshot.cluster_cards[0].cluster_id
     assert any(
+        preview.evidence_id == carrier_evidence_id
+        for card in from_parts.cluster_cards
+        for preview in card.evidence_previews
+    )
+    assert any(
         preview.evidence_id == caselaw_evidence_id
         for card in from_parts.cluster_cards
         for preview in card.evidence_previews
@@ -179,6 +186,7 @@ def test_build_evidence_board_from_parts_matches_snapshot_builder():
 
 def test_evidence_board_payload_round_trips_with_schema_version():
     parts = _sample_parts()
+    carrier_evidence_id = carrier_doc_pack_to_evidence_items(parts[2])[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(parts[3])[0].evidence_id
     board = build_evidence_board_from_parts(*parts)
 
@@ -190,6 +198,7 @@ def test_evidence_board_payload_round_trips_with_schema_version():
     assert payload["schema_version"] == "v2alpha1"
     assert restored.cluster_cards[0].cluster_id == board.cluster_cards[0].cluster_id
     assert "EVIDENCE BOARD" in rendered
+    assert carrier_evidence_id in rendered
     assert caselaw_evidence_id in rendered
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -337,7 +337,7 @@ def test_render_includes_canonical_evidence_index_rows():
     md = render_markdown_memo(*_sample_data())
 
     assert "weather-source-1" in md
-    assert "carrier-document-1" in md
+    assert "carrier-document-denial-" in md
     assert "caselaw-case-123-so-3d-456-" in md
     assert "citation-check-1" in md
 

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -8,6 +8,7 @@ from war_room.models import (
     CaseIntake,
     QuerySpec,
     adapt_citation_verify_pack,
+    carrier_doc_pack_to_evidence_items,
     caselaw_pack_to_evidence_items,
     citation_verify_pack_to_payload,
     memo_render_input_from_parts,
@@ -119,6 +120,90 @@ def _sample_payloads():
     query_plan = [QuerySpec(module="weather", query="test query", category="test")]
 
     return intake, weather, carrier, caselaw, citecheck, query_plan
+
+
+def test_carrier_evidence_adapter_returns_stable_ids_for_repeated_payloads():
+    _, _, carrier, _, _, _ = _sample_payloads()
+
+    first_ids = [item.evidence_id for item in carrier_doc_pack_to_evidence_items(carrier)]
+    second_ids = [item.evidence_id for item in carrier_doc_pack_to_evidence_items(carrier)]
+
+    assert first_ids == second_ids
+    assert first_ids[0].startswith("carrier-document-denial-")
+    assert first_ids[0] != "carrier-document-1"
+
+
+def test_carrier_evidence_adapter_does_not_collapse_distinct_document_rows():
+    _, _, carrier, _, _, _ = _sample_payloads()
+    carrier["document_pack"].append(
+        {
+            "doc_type": "Regulatory Action",
+            "title": "Doc follow-up",
+            "url": "https://example.com/doc",
+            "badge": "professional",
+            "why_it_matters": "Same URL, distinct document row.",
+        }
+    )
+
+    evidence_ids = [item.evidence_id for item in carrier_doc_pack_to_evidence_items(carrier)]
+
+    assert len(evidence_ids) == 2
+    assert len(set(evidence_ids)) == 2
+
+
+def test_carrier_evidence_adapter_preserves_document_metadata():
+    _, _, carrier, _, _, _ = _sample_payloads()
+    document = carrier["document_pack"][0]
+    document.update(
+        {
+            "badge": "official",
+            "source_class": "government_guidance",
+            "source_tier": "official",
+            "is_primary_authority": True,
+        }
+    )
+    carrier["sources"][0]["url"] = document["url"]
+
+    item = carrier_doc_pack_to_evidence_items(carrier)[0]
+
+    assert item.module == "carrier"
+    assert item.evidence_type == "denial"
+    assert item.title == "Doc"
+    assert item.summary == "Relevant"
+    assert item.url == "https://example.com/doc"
+    assert item.badge == "official"
+    assert item.source_reason == "Professional source"
+    assert item.source_class == "government_guidance"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+    assert item.authority_key == "authority:doc"
+
+
+def test_carrier_evidence_adapter_infers_primary_authority_when_field_missing():
+    _, _, carrier, _, _, _ = _sample_payloads()
+    document = carrier["document_pack"][0]
+    document.update(
+        {
+            "doc_type": "Regulatory Action",
+            "title": "Sebo v. American Home Assurance Co.",
+            "url": "https://www.courtlistener.com/opinion/12345/sebo-v-american-home/",
+            "badge": "official",
+        }
+    )
+
+    assert "is_primary_authority" not in document
+
+    item = carrier_doc_pack_to_evidence_items(carrier)[0]
+
+    assert item.source_class == "court_opinion"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+
+    document["is_primary_authority"] = False
+
+    explicit_item = carrier_doc_pack_to_evidence_items(carrier)[0]
+
+    assert explicit_item.is_primary_authority is False
 
 
 def test_caselaw_evidence_adapter_returns_stable_ids_for_repeated_payloads():
@@ -263,6 +348,7 @@ def test_memo_render_input_from_parts_accepts_mixed_shapes():
 
 def test_run_audit_snapshot_builds_canonical_entities():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    carrier_evidence_id = carrier_doc_pack_to_evidence_items(carrier)[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
     snapshot = run_audit_snapshot_from_parts(
@@ -295,12 +381,17 @@ def test_run_audit_snapshot_builds_canonical_entities():
     assert payload["schema_version"] == "v2alpha1"
     assert payload["evidence_items"][0]["evidence_id"] == "weather-source-1"
     assert any(
+        item.evidence_id == carrier_evidence_id and item.module == "carrier"
+        for item in snapshot.evidence_items
+    )
+    assert any(
         item.evidence_id == caselaw_evidence_id and item.module == "caselaw"
         for item in snapshot.evidence_items
     )
     assert payload["evidence_clusters"][0]["cluster_id"] == "cluster-1"
     assert payload["evidence_clusters"][2]["cluster_type"] == "citation"
     assert snapshot.memo_claims[0].cluster_ids == ["cluster-1"]
+    assert carrier_evidence_id in snapshot.memo_claims[1].evidence_ids
     assert caselaw_evidence_id in snapshot.memo_claims[2].evidence_ids
     assert snapshot.memo_claims[2].cluster_ids == ["cluster-3"]
     assert snapshot.quality_snapshot.source_class_counts["government_guidance"] == 1


### PR DESCRIPTION
## Summary

Closes #96.

Adds one focused adapter seam for current carrier module output: `carrier_doc_pack_to_evidence_items(...)` converts existing `CarrierDocPack` / `CarrierDocument` data into canonical `EvidenceItem` records used by the current `RunAuditSnapshot` and Evidence Board flow.

## What changed

- Extracted the inline carrier `EvidenceItem` mapping from `run_audit_snapshot_from_memo_input` into a dedicated adapter helper in `src/war_room/models.py`.
- Replaced positional carrier IDs like `carrier-document-1` with deterministic IDs derived from stable carrier document attributes, existing authority-key inputs, and carrier snapshot context.
- Preserved URL, source tier/class, primary-authority flag behavior, title, summary/why-it-matters, badge, source reason, document type/evidence type, authority-key clustering, memo-claim provenance, quality snapshot, export, and Evidence Board compatibility.
- Added focused tests for stable repeated IDs, distinct document-row IDs, metadata preservation, audit snapshot compatibility, Evidence Board rendering, memo evidence-index output, and explicit-vs-inferred primary-authority behavior.
- Logged the build session in `docs/SESSION_LOG.md`.

## Non-goals kept out

No full #12 implementation, global evidence graph rewrite, database, persistence, auth, users/sessions, queues/workers, dashboard/frontend, API framework, production runtime, live retrieval changes, fixture/cache/citation provider changes, AI scoring, ML dedupe, broad title-similarity dedupe, readiness-level changes, release claim changes, pilot execution, firm memory, notebook behavior change, or docx/pdf export pipeline.

## Validation

- `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q` -> `57 passed in 2.55s`
- `python -m pytest -q` -> `444 passed in 17.21s`
- `git diff --check` -> passed
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `444 passed in 18.09s`