### PR TITLE
[codex] Add weather evidence adapter

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2778,3 +2778,48 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `444 passed in 18.09s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-96-carrier-evidence-adapter_20260520t070016z.json`.
+
+## Session 129 - Issue 98 Weather Evidence Adapter
+Date: 2026-05-20
+Status: Complete
+
+- Completed issue `#98` as the weather counterpart to the narrow issue `#12`
+  evidence/provenance adapter slices from issues `#94` and `#96`.
+- What changed:
+  - Added `weather_brief_to_evidence_items(...)` in `src/war_room/models.py`
+    as a focused adapter seam from current `WeatherBrief` / `SourceReference`
+    data into canonical `EvidenceItem` records.
+  - Replaced positional weather evidence IDs like `weather-source-1` with
+    deterministic IDs derived from stable weather source attributes, the
+    observation/event-summary fallback, and the current authority-key inputs.
+  - Kept `RunAuditSnapshot`, memo claims, evidence clusters, quality snapshot,
+    export rendering, and Evidence Board construction on the existing flow by
+    routing only the weather evidence-item mapping through the new adapter.
+  - Added focused tests for repeated stable weather IDs, distinct source-row
+    IDs, metadata preservation, audit-snapshot inclusion, evidence-board
+    rendering, memo evidence-index output, and explicit-vs-inferred
+    primary-authority behavior.
+- Decisions added:
+  - Weather evidence IDs now use source title/URL/badge/reason/source class,
+    explicit primary-authority value when present, summary fallback context,
+    event summary, authority key, and a short deterministic digest, with only
+    deterministic collision suffixing for duplicate stable IDs within one
+    payload.
+  - Weather source rows preserve explicit `is_primary_authority` true/false
+    values and fall back to `score_url(...)` only when the field is omitted.
+- Decisions not added:
+  - no full issue `#12` evidence graph implementation, global evidence graph
+    rewrite, database, persistence, auth, users, sessions, queues, workers,
+    dashboard, frontend, API framework, production runtime, live retrieval
+    change, fixture/cache/citation provider change, AI scoring, ML dedupe,
+    broad title-similarity dedupe, readiness-level change, release claim,
+    pilot execution, firm memory, notebook behavior change, or docx/pdf export
+    pipeline was added.
+- Validation:
+  - `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q`
+    -> `61 passed in 3.53s`.
+  - `git diff --check` -> passed.
+  - `python -m pytest -q` -> `448 passed in 14.67s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `448 passed in 13.51s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-98-weather-evidence-adapter_20260520t073832z.json`.

--- a/src/war_room/__init__.py
+++ b/src/war_room/__init__.py
@@ -99,7 +99,6 @@ _EXPORTS = {
     "run_stage_to_payload": "war_room.models",
     "run_timeline_to_payload": "war_room.models",
     "run_to_payload": "war_room.models",
-    "weather_brief_to_evidence_items": "war_room.models",
     "weather_brief_to_payload": "war_room.models",
     "carrier_doc_pack_to_payload": "war_room.models",
     "caselaw_pack_to_payload": "war_room.models",

--- a/src/war_room/__init__.py
+++ b/src/war_room/__init__.py
@@ -99,6 +99,7 @@ _EXPORTS = {
     "run_stage_to_payload": "war_room.models",
     "run_timeline_to_payload": "war_room.models",
     "run_to_payload": "war_room.models",
+    "weather_brief_to_evidence_items": "war_room.models",
     "weather_brief_to_payload": "war_room.models",
     "carrier_doc_pack_to_payload": "war_room.models",
     "caselaw_pack_to_payload": "war_room.models",

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1055,6 +1055,54 @@ def adapt_run_timeline(
     return RunTimelineReadModel.model_validate(payload)
 
 
+def weather_brief_to_evidence_items(
+    payload: Mapping[str, Any] | WeatherBrief,
+) -> list[EvidenceItem]:
+    """Adapt current weather module output into canonical evidence items."""
+    weather = adapt_weather_brief(payload)
+    evidence_items: list[EvidenceItem] = []
+    used_evidence_ids: dict[str, int] = {}
+
+    for index, source in enumerate(weather.sources, 1):
+        source_profile = score_url(source.url, source.title)
+        summary = (
+            weather.key_observations[index - 1]
+            if index <= len(weather.key_observations)
+            else weather.event_summary
+        )
+        authority_key = _authority_key_from_parts(
+            url=source.url,
+            title=source.title,
+        )
+        evidence_items.append(
+            EvidenceItem(
+                evidence_id=_weather_evidence_id(
+                    weather=weather,
+                    source=source,
+                    summary=summary,
+                    authority_key=authority_key,
+                    used_evidence_ids=used_evidence_ids,
+                ),
+                module="weather",
+                evidence_type="weather_source",
+                title=source.title,
+                summary=summary,
+                url=source.url,
+                badge=source.badge,
+                source_reason=source.reason,
+                source_class=source.source_class or source_profile.get("source_class"),
+                source_tier=source_profile.get("tier"),
+                is_primary_authority=_weather_source_is_primary_authority(
+                    source,
+                    source_profile,
+                ),
+                authority_key=authority_key,
+            )
+        )
+
+    return evidence_items
+
+
 def carrier_doc_pack_to_evidence_items(
     payload: Mapping[str, Any] | CarrierDocPack,
 ) -> list[EvidenceItem]:
@@ -1185,37 +1233,11 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
         "citation_verify": [],
     }
 
-    weather_observations = weather_payload.get("key_observations", [])
-    for index, source in enumerate(weather_payload.get("sources", []), 1):
-        evidence_id = f"weather-source-{index}"
-        source_profile = score_url(source.get("url", ""), source.get("title", ""))
-        summary = (
-            weather_observations[index - 1]
-            if index <= len(weather_observations)
-            else weather_payload.get("event_summary", "")
-        )
-        evidence_items.append(
-            EvidenceItem(
-                evidence_id=evidence_id,
-                module="weather",
-                evidence_type="weather_source",
-                title=source.get("title", ""),
-                summary=summary,
-                url=source.get("url"),
-                badge=source.get("badge", ""),
-                source_reason=source.get("reason"),
-                source_class=source.get("source_class") or source_profile.get("source_class"),
-                source_tier=source_profile.get("tier"),
-                is_primary_authority=bool(
-                    source.get("is_primary_authority", source_profile.get("is_primary_authority"))
-                ),
-                authority_key=_authority_key_from_parts(
-                    url=source.get("url"),
-                    title=source.get("title"),
-                ),
-            )
-        )
-        evidence_ids_by_module["weather"].append(evidence_id)
+    weather_evidence_items = weather_brief_to_evidence_items(memo_input.weather)
+    evidence_items.extend(weather_evidence_items)
+    evidence_ids_by_module["weather"].extend(
+        item.evidence_id for item in weather_evidence_items
+    )
 
     carrier_evidence_items = carrier_doc_pack_to_evidence_items(memo_input.carrier)
     evidence_items.extend(carrier_evidence_items)
@@ -1785,6 +1807,50 @@ def _normalize_authority_name(value: str | None) -> str:
         return ""
     normalized = re.sub(r"[^a-z0-9]+", " ", value.lower())
     return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _weather_evidence_id(
+    *,
+    weather: WeatherBrief,
+    source: SourceReference,
+    summary: str,
+    authority_key: str | None,
+    used_evidence_ids: dict[str, int],
+) -> str:
+    explicit_primary_authority = (
+        str(source.is_primary_authority).lower()
+        if "is_primary_authority" in source.model_fields_set
+        else ""
+    )
+    identity_parts = [
+        authority_key or "",
+        _normalize_cluster_url(source.url),
+        _normalize_authority_name(source.title),
+        _normalize_authority_name(source.badge),
+        _normalize_authority_name(source.reason),
+        _normalize_authority_name(source.source_class),
+        explicit_primary_authority,
+        _normalize_authority_name(summary),
+        _normalize_authority_name(weather.event_summary),
+    ]
+    digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[:10]
+    display_token = _stable_token(source.title or source.badge or authority_key or source.url)
+    display_token = display_token[:48].rstrip("-") or "source"
+    base_id = f"weather-source-{display_token}-{digest}"
+    collision_count = used_evidence_ids.get(base_id, 0) + 1
+    used_evidence_ids[base_id] = collision_count
+    if collision_count == 1:
+        return base_id
+    return f"{base_id}-{collision_count}"
+
+
+def _weather_source_is_primary_authority(
+    source: SourceReference,
+    source_profile: Mapping[str, Any],
+) -> bool:
+    if "is_primary_authority" in source.model_fields_set:
+        return bool(source.is_primary_authority)
+    return bool(source_profile.get("is_primary_authority"))
 
 
 def _carrier_evidence_id(

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1077,9 +1077,7 @@ def weather_brief_to_evidence_items(
         evidence_items.append(
             EvidenceItem(
                 evidence_id=_weather_evidence_id(
-                    weather=weather,
                     source=source,
-                    summary=summary,
                     authority_key=authority_key,
                     used_evidence_ids=used_evidence_ids,
                 ),
@@ -1811,27 +1809,16 @@ def _normalize_authority_name(value: str | None) -> str:
 
 def _weather_evidence_id(
     *,
-    weather: WeatherBrief,
     source: SourceReference,
-    summary: str,
     authority_key: str | None,
     used_evidence_ids: dict[str, int],
 ) -> str:
-    explicit_primary_authority = (
-        str(source.is_primary_authority).lower()
-        if "is_primary_authority" in source.model_fields_set
-        else ""
-    )
     identity_parts = [
         authority_key or "",
         _normalize_cluster_url(source.url),
         _normalize_authority_name(source.title),
         _normalize_authority_name(source.badge),
-        _normalize_authority_name(source.reason),
         _normalize_authority_name(source.source_class),
-        explicit_primary_authority,
-        _normalize_authority_name(summary),
-        _normalize_authority_name(weather.event_summary),
     ]
     digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[:10]
     display_token = _stable_token(source.title or source.badge or authority_key or source.url)
@@ -1848,6 +1835,8 @@ def _weather_source_is_primary_authority(
     source: SourceReference,
     source_profile: Mapping[str, Any],
 ) -> bool:
+    # model_fields_set distinguishes explicit true/false from omitted fields,
+    # though dump/reload paths may mark default values as set.
     if "is_primary_authority" in source.model_fields_set:
         return bool(source.is_primary_authority)
     return bool(source_profile.get("is_primary_authority"))

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -20,6 +20,7 @@ from war_room.models import (
     caselaw_pack_to_evidence_items,
     evidence_board_to_payload,
     run_audit_snapshot_from_parts,
+    weather_brief_to_evidence_items,
 )
 
 
@@ -147,6 +148,7 @@ def test_build_evidence_board_links_claims_and_review_events_to_clusters():
 
 def test_build_evidence_board_from_parts_matches_snapshot_builder():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_parts()
+    weather_evidence_id = weather_brief_to_evidence_items(weather)[0].evidence_id
     carrier_evidence_id = carrier_doc_pack_to_evidence_items(carrier)[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
@@ -173,6 +175,11 @@ def test_build_evidence_board_from_parts_matches_snapshot_builder():
     assert from_parts.review_required_clusters == from_snapshot.review_required_clusters
     assert from_parts.cluster_cards[0].cluster_id == from_snapshot.cluster_cards[0].cluster_id
     assert any(
+        preview.evidence_id == weather_evidence_id
+        for card in from_parts.cluster_cards
+        for preview in card.evidence_previews
+    )
+    assert any(
         preview.evidence_id == carrier_evidence_id
         for card in from_parts.cluster_cards
         for preview in card.evidence_previews
@@ -186,6 +193,7 @@ def test_build_evidence_board_from_parts_matches_snapshot_builder():
 
 def test_evidence_board_payload_round_trips_with_schema_version():
     parts = _sample_parts()
+    weather_evidence_id = weather_brief_to_evidence_items(parts[1])[0].evidence_id
     carrier_evidence_id = carrier_doc_pack_to_evidence_items(parts[2])[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(parts[3])[0].evidence_id
     board = build_evidence_board_from_parts(*parts)
@@ -198,6 +206,7 @@ def test_evidence_board_payload_round_trips_with_schema_version():
     assert payload["schema_version"] == "v2alpha1"
     assert restored.cluster_cards[0].cluster_id == board.cluster_cards[0].cluster_id
     assert "EVIDENCE BOARD" in rendered
+    assert weather_evidence_id in rendered
     assert carrier_evidence_id in rendered
     assert caselaw_evidence_id in rendered
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -336,7 +336,7 @@ def test_render_surfaces_claim_cluster_references():
 def test_render_includes_canonical_evidence_index_rows():
     md = render_markdown_memo(*_sample_data())
 
-    assert "weather-source-1" in md
+    assert "weather-source-nws-report-" in md
     assert "carrier-document-denial-" in md
     assert "caselaw-case-123-so-3d-456-" in md
     assert "citation-check-1" in md

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -152,6 +152,17 @@ def test_weather_evidence_adapter_does_not_collapse_distinct_source_rows():
     assert len(set(evidence_ids)) == 2
 
 
+def test_weather_evidence_adapter_suffixes_duplicate_source_rows():
+    _, weather, _, _, _, _ = _sample_payloads()
+    weather["key_observations"].append("Winds of 120 mph")
+    weather["sources"].append(dict(weather["sources"][0]))
+
+    evidence_ids = [item.evidence_id for item in weather_brief_to_evidence_items(weather)]
+    base_id = evidence_ids[0]
+
+    assert evidence_ids == [base_id, f"{base_id}-2"]
+
+
 def test_weather_evidence_adapter_preserves_source_metadata():
     _, weather, _, _, _, _ = _sample_payloads()
     weather["key_observations"][0] = "Observed 120 mph gusts in Pinellas County."

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -14,6 +14,7 @@ from war_room.models import (
     memo_render_input_from_parts,
     run_audit_snapshot_from_parts,
     run_audit_snapshot_to_payload,
+    weather_brief_to_evidence_items,
 )
 
 
@@ -120,6 +121,90 @@ def _sample_payloads():
     query_plan = [QuerySpec(module="weather", query="test query", category="test")]
 
     return intake, weather, carrier, caselaw, citecheck, query_plan
+
+
+def test_weather_evidence_adapter_returns_stable_ids_for_repeated_payloads():
+    _, weather, _, _, _, _ = _sample_payloads()
+
+    first_ids = [item.evidence_id for item in weather_brief_to_evidence_items(weather)]
+    second_ids = [item.evidence_id for item in weather_brief_to_evidence_items(weather)]
+
+    assert first_ids == second_ids
+    assert first_ids[0].startswith("weather-source-nws-report-")
+    assert first_ids[0] != "weather-source-1"
+
+
+def test_weather_evidence_adapter_does_not_collapse_distinct_source_rows():
+    _, weather, _, _, _, _ = _sample_payloads()
+    weather["key_observations"].append("Storm surge was reported near the county shoreline.")
+    weather["sources"].append(
+        {
+            "title": "NWS follow-up report",
+            "url": "https://weather.gov/r",
+            "badge": "official",
+            "reason": "Second county-specific weather source row.",
+        }
+    )
+
+    evidence_ids = [item.evidence_id for item in weather_brief_to_evidence_items(weather)]
+
+    assert len(evidence_ids) == 2
+    assert len(set(evidence_ids)) == 2
+
+
+def test_weather_evidence_adapter_preserves_source_metadata():
+    _, weather, _, _, _, _ = _sample_payloads()
+    weather["key_observations"][0] = "Observed 120 mph gusts in Pinellas County."
+    weather["sources"][0].update(
+        {
+            "title": "NWS Local Storm Report",
+            "url": "https://weather.gov/milton/local",
+            "badge": "official",
+            "reason": "County-specific official weather corroboration.",
+            "source_class": "government_guidance",
+            "is_primary_authority": True,
+        }
+    )
+
+    item = weather_brief_to_evidence_items(weather)[0]
+
+    assert item.module == "weather"
+    assert item.evidence_type == "weather_source"
+    assert item.title == "NWS Local Storm Report"
+    assert item.summary == "Observed 120 mph gusts in Pinellas County."
+    assert item.url == "https://weather.gov/milton/local"
+    assert item.badge == "official"
+    assert item.source_reason == "County-specific official weather corroboration."
+    assert item.source_class == "government_guidance"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+    assert item.authority_key == "authority:nws local storm report"
+
+
+def test_weather_evidence_adapter_infers_primary_authority_when_field_missing():
+    _, weather, _, _, _, _ = _sample_payloads()
+    source = weather["sources"][0]
+    source.update(
+        {
+            "title": "Sebo v. American Home Assurance Co.",
+            "url": "https://www.courtlistener.com/opinion/12345/sebo-v-american-home/",
+            "badge": "official",
+        }
+    )
+
+    assert "is_primary_authority" not in source
+
+    item = weather_brief_to_evidence_items(weather)[0]
+
+    assert item.source_class == "court_opinion"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+
+    source["is_primary_authority"] = False
+
+    explicit_item = weather_brief_to_evidence_items(weather)[0]
+
+    assert explicit_item.is_primary_authority is False
 
 
 def test_carrier_evidence_adapter_returns_stable_ids_for_repeated_payloads():
@@ -348,6 +433,7 @@ def test_memo_render_input_from_parts_accepts_mixed_shapes():
 
 def test_run_audit_snapshot_builds_canonical_entities():
     intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    weather_evidence_id = weather_brief_to_evidence_items(weather)[0].evidence_id
     carrier_evidence_id = carrier_doc_pack_to_evidence_items(carrier)[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
 
@@ -379,7 +465,11 @@ def test_run_audit_snapshot_builds_canonical_entities():
     assert "Appendix: Evidence Index" in snapshot.export_artifact.section_titles
     assert snapshot.export_artifact.section_ids[:3] == ["trust-snapshot", "case-intake", "weather-corroboration"]
     assert payload["schema_version"] == "v2alpha1"
-    assert payload["evidence_items"][0]["evidence_id"] == "weather-source-1"
+    assert payload["evidence_items"][0]["evidence_id"] == weather_evidence_id
+    assert any(
+        item.evidence_id == weather_evidence_id and item.module == "weather"
+        for item in snapshot.evidence_items
+    )
     assert any(
         item.evidence_id == carrier_evidence_id and item.module == "carrier"
         for item in snapshot.evidence_items
@@ -391,6 +481,7 @@ def test_run_audit_snapshot_builds_canonical_entities():
     assert payload["evidence_clusters"][0]["cluster_id"] == "cluster-1"
     assert payload["evidence_clusters"][2]["cluster_type"] == "citation"
     assert snapshot.memo_claims[0].cluster_ids == ["cluster-1"]
+    assert weather_evidence_id in snapshot.memo_claims[0].evidence_ids
     assert carrier_evidence_id in snapshot.memo_claims[1].evidence_ids
     assert caselaw_evidence_id in snapshot.memo_claims[2].evidence_ids
     assert snapshot.memo_claims[2].cluster_ids == ["cluster-3"]


### PR DESCRIPTION
## Summary

Closes #98.

Adds one focused adapter seam for current weather module output: `weather_brief_to_evidence_items(...)` converts existing `WeatherBrief` / `SourceReference` data into canonical `EvidenceItem` records used by the current `RunAuditSnapshot` and Evidence Board flow.

## What changed

- Extracted the inline weather `EvidenceItem` mapping from `run_audit_snapshot_from_memo_input` into a dedicated adapter helper in `src/war_room/models.py`.
- Replaced positional weather IDs like `weather-source-1` with deterministic IDs derived from stable weather source identity fields and existing authority-key inputs.
- Preserved existing snapshot, memo-claim, evidence-cluster, quality-snapshot, export, and Evidence Board compatibility.
- Addressed Claude review feedback by removing unstable free-text fields from the weather ID digest, removing the package-level lazy export, adding duplicate-source-row suffix coverage, and documenting the `model_fields_set` caveat.

## Validation

- `git diff --check` -> passed
- `python -m pytest tests/test_models.py tests/test_evidence_board.py tests/test_memo_contracts.py tests/test_export.py -q` -> `62 passed`
- `python -m pytest -q` -> `449 passed`
- `python -m war_room --verify` -> passed