### PR TITLE
[codex] Review remaining issue-12 scope after evidence adapters

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -154,6 +154,7 @@ Core implementation lives in `src/war_room/`.
 - [examples/guided_intake_milton_preview.md](examples/guided_intake_milton_preview.md): deterministic issue `#11` Milton guided-intake preview for the future pre-run intake surface
 - [ISSUE_11_RUN_STATUS_UX_SPEC.md](ISSUE_11_RUN_STATUS_UX_SPEC.md): narrow issue `#11` run-status UX/spec slice over the existing `status_presentation` payload
 - [examples/run_status_milton_degraded.md](examples/run_status_milton_degraded.md): deterministic issue `#11` Milton degraded run-status preview derived from the existing transport/status payload
+- [ISSUE_12_REMAINING_SCOPE.md](ISSUE_12_REMAINING_SCOPE.md): docs-only issue `#12` remaining-scope review after the landed caselaw, carrier, and weather evidence adapters
 - [ROADMAP.md](ROADMAP.md): plain-language roadmap and active execution order
 - [V2_WORKFLOW_IA.md](V2_WORKFLOW_IA.md): canonical V2 workflow, IA, and design-system rules
 - [V2_EVIDENCE_SCHEMA.md](V2_EVIDENCE_SCHEMA.md): canonical V2 evidence graph, audit schema, and versioning rules

--- a/docs/ISSUE_12_REMAINING_SCOPE.md
+++ b/docs/ISSUE_12_REMAINING_SCOPE.md
@@ -50,9 +50,10 @@ Narrow implementation intent:
 - Add a named adapter from current `CitationVerifyPack` / `CitationCheck` output into canonical `EvidenceItem` rows.
 - Replace current positional citation evidence IDs such as `citation-check-1` with deterministic provenance-oriented IDs.
 - Preserve citation status semantics: `verified`, `uncertain`, and `not_found` remain confidence signals requiring attorney review as appropriate.
-- Preserve trust metadata already produced by citation verification, including `status_reason`, `trust_explanation`, `source_tier`, `source_class`, `is_primary_authority`, `confidence`, `citation`, `case_name`, and `source_url` where present.
+- Carry forward the trust metadata the current inline builder already maps onto `EvidenceItem`: `source_class`, `source_tier`, `is_primary_authority`, `citation`, and `case_name`/`source_url` via `title`/`url`.
+- `status_reason`, `trust_explanation`, and `confidence` exist on `CitationCheck` but have no `EvidenceItem` slot today and are not carried by the current builder. Carrying them requires an `EvidenceItem` field addition — treat that as an explicit, separate scoping decision, not part of this seam-extraction slice.
 - Route `run_audit_snapshot_from_memo_input(...)` through the new adapter while preserving existing Evidence Board, Issue Workspace, Memo Composer, Export History, release-scorecard, and offline fixture behavior.
-- Add focused tests for stable IDs, duplicate-row suffixing, metadata preservation, audit-snapshot inclusion, Evidence Board rendering, memo/export evidence-index behavior, and sparse citation metadata.
+- Add focused tests for stable IDs, duplicate-row suffixing, existing-field metadata preservation, audit-snapshot inclusion, Evidence Board rendering, memo/export evidence-index behavior, and sparse citation metadata.
 
 Validation should stay local and fixture-backed:
 

--- a/docs/ISSUE_12_REMAINING_SCOPE.md
+++ b/docs/ISSUE_12_REMAINING_SCOPE.md
@@ -1,0 +1,92 @@
+# Issue 12 Remaining Scope Review
+
+Date: 2026-05-20
+
+## Purpose
+
+Issue [#12](https://github.com/itprodirect/cat-loss-war-room/issues/12) is still the umbrella for evidence normalization, dedupe, provenance, confidence annotations, and canonical evidence behavior. This review narrows the next implementation step after the landed issue `#94`, `#96`, and `#98` evidence-adapter slices.
+
+The current decision is:
+
+- continue with one narrow citation-verify evidence adapter child issue next;
+- do not treat issue `#12` as ready for a broad dedupe, persistence, UI, or full evidence graph implementation;
+- do not create a separate adapter-status map before the citation-verify slice unless maintainers want to plan multiple adapter families at once.
+
+## Current Adapter Status
+
+The canonical source family for issue `#12` adapter work is the set of current module outputs that become `EvidenceItem` rows in `RunAuditSnapshot`.
+
+| Source family | Current status | Adapter surface | Scope boundary |
+| --- | --- | --- | --- |
+| Weather corroboration | Landed | `weather_brief_to_evidence_items(...)` in `src/war_room/models.py` | Maps current `WeatherBrief` / `SourceReference` rows to deterministic provenance-oriented `EvidenceItem` IDs. |
+| Carrier intelligence | Landed | `carrier_doc_pack_to_evidence_items(...)` in `src/war_room/models.py` | Maps current `CarrierDocPack` / `CarrierDocument` rows to deterministic provenance-oriented `EvidenceItem` IDs. |
+| Case law | Landed | `caselaw_pack_to_evidence_items(...)` in `src/war_room/models.py` | Maps current `CaseLawPack` / `CaseIssue` / `CaseEntry` rows to deterministic provenance-oriented `EvidenceItem` IDs. |
+| Citation verification | Partially present, adapter not landed | Current `run_audit_snapshot_from_memo_input(...)` builds `citation_verify` evidence rows inline from `CitationVerifyPack` checks | Needs a named adapter seam and stable provenance-oriented IDs before broader issue `#12` work continues. |
+
+The landed weather, carrier, and caselaw adapters are narrow seams over current notebook-era module output. They preserve `RunAuditSnapshot`, Evidence Board, memo/export behavior, fixture-backed tests, and the current offline validation lane. They are not a full V2 evidence graph, storage layer, dedupe engine, dashboard, or API integration.
+
+## Source Families Still Lacking Adapters
+
+Only the citation-verify source family still lacks a dedicated canonical evidence adapter among today's evidence-producing module outputs.
+
+The current code already has typed citation verification contracts through `CitationVerifyPack`, `CitationCheck`, `CitationSummary`, `adapt_citation_verify_pack(...)`, and `citation_verify_pack_to_payload(...)`. It also already emits `citation_verify` `EvidenceItem` rows inside `run_audit_snapshot_from_memo_input(...)`. The missing piece is a named adapter equivalent to the landed source-family adapters, for example `citation_verify_pack_to_evidence_items(...)`.
+
+That adapter should only translate existing citation-check output into canonical `EvidenceItem` rows. It should not change citation search behavior, add live retrieval, harden ambiguity logic, change badge/status vocabulary, or claim legal verification.
+
+Current non-adapter surfaces should stay out of this child issue:
+
+- `RetrievalTask` and `RunEvent` are canonical runtime/audit entities, not evidence source-family adapters.
+- `MemoClaim`, `ReviewEvent`, `EvidenceCluster`, and export artifacts are provenance and review-linkage surfaces, not the next adapter target.
+- Intake, research-plan, memo-assembly, and export stages should not become evidence adapters just to fill a table.
+
+## Recommended Next Child Issue
+
+Create the next child as:
+
+**Issue #12 child: Add citation-verify evidence adapter over current `CitationVerifyPack` output.**
+
+Narrow implementation intent:
+
+- Add a named adapter from current `CitationVerifyPack` / `CitationCheck` output into canonical `EvidenceItem` rows.
+- Replace current positional citation evidence IDs such as `citation-check-1` with deterministic provenance-oriented IDs.
+- Preserve citation status semantics: `verified`, `uncertain`, and `not_found` remain confidence signals requiring attorney review as appropriate.
+- Preserve trust metadata already produced by citation verification, including `status_reason`, `trust_explanation`, `source_tier`, `source_class`, `is_primary_authority`, `confidence`, `citation`, `case_name`, and `source_url` where present.
+- Route `run_audit_snapshot_from_memo_input(...)` through the new adapter while preserving existing Evidence Board, Issue Workspace, Memo Composer, Export History, release-scorecard, and offline fixture behavior.
+- Add focused tests for stable IDs, duplicate-row suffixing, metadata preservation, audit-snapshot inclusion, Evidence Board rendering, memo/export evidence-index behavior, and sparse citation metadata.
+
+Validation should stay local and fixture-backed:
+
+```bash
+git diff --check
+python -m pytest -q
+```
+
+## Adapter-Status Map Decision
+
+A separate adapter-status map is not needed before the citation-verify adapter. This review is enough status mapping for the next child because there is only one remaining evidence-producing module family without a named adapter.
+
+Add a dedicated adapter-status map later only if maintainers want to coordinate more than one of these broader tracks:
+
+- URL/citation dedupe regression behavior across all five fixture lanes;
+- full canonical graph persistence and API response contracts;
+- provenance-through-edits in the human review workflow;
+- cross-surface traceability from memo claims to clusters and export artifacts;
+- issue `#14` citation verification hardening beyond adapter translation.
+
+## Explicitly Deferred Work
+
+These items remain outside the next adapter slice and outside this docs-only review:
+
+- broad dedupe by URL, content fingerprint, title similarity, or ML scoring;
+- a database, persistence layer, storage migration, or full canonical graph store;
+- dashboard, frontend, app shell, auth, queues, workers, sessions, or production API routing;
+- live retrieval changes, new providers, provider ranking changes, or citation-search behavior changes;
+- AI scoring, generative evidence synthesis, or replacement of deterministic source scoring;
+- provenance-through-edits, approvals, revisions, or broader human-review workflow design;
+- a claim that the V2 evidence graph is complete.
+
+## How Future Codex Work Should Use This
+
+For the next child issue, Codex should start from `src/war_room/models.py` and the existing tests in `tests/test_memo_contracts.py`, `tests/test_evidence_board.py`, `tests/test_export.py`, and `tests/test_issue_workspace.py`. The implementation should mirror the landed weather, carrier, and caselaw adapter pattern and keep the citation-verify change to adapter extraction plus deterministic ID behavior.
+
+Do not turn issue `#12` into a broad implementation umbrella. The next useful code slice is the citation-verify adapter only.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2854,3 +2854,37 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `449 passed in 10.30s`; verify manifest written under
     `runs/verify/2026-05-20_docs-post-adapter-state-sync_20260520t081618z.json`.
+
+## Session 131 - Issue 101 Remaining Issue 12 Scope Review
+Date: 2026-05-20
+Status: Complete
+
+- Completed issue `#101` as a docs-only issue `#12` remaining-scope review
+  after the landed caselaw, carrier, and weather evidence-adapter slices.
+- What changed:
+  - Added `docs/ISSUE_12_REMAINING_SCOPE.md` to document current adapter
+    status, the remaining citation-verify adapter gap, and the next narrow
+    child issue.
+  - Linked the new review from `docs/HANDOFF.md` and updated
+    `docs/heartbeat.md` so future agents find the current boundary before
+    treating issue `#12` as a broad implementation umbrella.
+  - Documented that a separate adapter-status map is not needed before the
+    citation-verify adapter because this review is enough for the single
+    remaining evidence-producing module family without a named adapter.
+- Decisions added:
+  - The next recommended issue `#12` child is a citation-verify evidence
+    adapter over current `CitationVerifyPack` output.
+  - The adapter-status map can wait unless maintainers want to coordinate
+    broader dedupe, persistence, review-workflow, API, or cross-surface
+    provenance work.
+- Decisions not added:
+  - no runtime code, tests, dependencies, notebooks, fixtures, live retrieval,
+    citation-search behavior, citation-verification hardening, database,
+    persistence, full V2 evidence graph, API framework, frontend, dashboard,
+    app shell, auth, queues, workers, AI scoring, generative behavior,
+    provenance-through-edits workflow, readiness-level change, Beta-ready
+    claim, Pilot-ready claim, production-ready claim, or legal-product claim
+    was added.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest -q` -> `449 passed in 11.69s`.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2888,3 +2888,28 @@ Status: Complete
 - Validation:
   - `git diff --check` -> passed.
   - `python -m pytest -q` -> `449 passed in 11.69s`.
+
+## Session 132 - PR 102 Citation-Verify Metadata Scope Wording
+Date: 2026-05-20
+Status: Complete
+
+- Applied the PR `#102` review cleanup for the issue `#101` / issue `#12`
+  remaining-scope review.
+- What changed:
+  - Clarified `docs/ISSUE_12_REMAINING_SCOPE.md` so the next
+    citation-verify adapter child only carries forward trust metadata the
+    current inline builder already maps onto existing `EvidenceItem` fields:
+    `source_class`, `source_tier`, `is_primary_authority`, `citation`, and
+    `case_name` / `source_url` through `title` / `url`.
+  - Documented that `status_reason`, `trust_explanation`, and `confidence`
+    exist on `CitationCheck` but do not currently have `EvidenceItem` slots and
+    would require a separate explicit schema decision.
+  - Tightened the recommended test wording from generic metadata preservation
+    to existing-field metadata preservation.
+- Decisions not added:
+  - no runtime code, tests, schemas, `EvidenceItem` fields, citation
+    verification behavior, fixtures, notebooks, CI workflows, dependencies,
+    README, handoff, or heartbeat changes were added.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest -q` -> `449 passed in 32.05s`.

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -3,13 +3,13 @@
 - Repo: `cat-loss-war-room`
 - Current milestone: Keep the notebook demo stable while issue `#12` evidence/provenance adapter work continues after the issue `#92` release-evidence reporting slice.
 - Current status: V0 demo is stable; active runtime is still `src/war_room/` plus `notebooks/01_case_war_room.ipynb`, not a full web app. The issue `#10` stack now has canonical run/stage vocabulary in `src/war_room/orchestration.py`, typed API boundary contracts in `src/war_room/orchestration_api_contracts.py`, an in-process offline service in `src/war_room/orchestration_service.py`, an operator-facing status presentation layer in `src/war_room/orchestration_status_view.py`, a dependency-free thin transport/request-handler wrapper in `src/war_room/orchestration_transport.py`, and a dev-only standard-library HTTP adapter in `src/war_room/orchestration_http.py`. Issue `#11` has documentation-only guided-intake and run-status UX/spec slices plus deterministic Milton previews. Issue `#27` has the human release-evidence reviewer guide, top-level `reviewer_summary`, and the issue `#92` / PR `#93` `ci_reporting_summary` inventory. Issue `#12` now has narrow evidence adapters landed for issue `#94` / PR `#95` caselaw output, issue `#96` / PR `#97` carrier output, and issue `#98` / PR `#99` weather output; the full V2 evidence graph, persistence layer, dashboard, and production API remain future work.
-- Current branch: `docs/post-adapter-state-sync`
-- Last validated: 2026-05-20 via `git diff --check`, `python -m pytest -q` (`449 passed in 11.59s`), and `python -m war_room --verify` (passed; embedded `pytest -q` reported `449 passed in 10.30s`; manifest `runs/verify/2026-05-20_docs-post-adapter-state-sync_20260520t081618z.json`).
-- Current focus: Docs-only current-state sync after the release-evidence reporting and evidence-adapter slices.
+- Current branch: `docs/issue-101-remaining-issue-12-scope`
+- Last validated: 2026-05-20 for issue `#101` via `git diff --check` and `python -m pytest -q` (`449 passed in 11.69s`); the prior current-state sync also passed `python -m war_room --verify` with manifest `runs/verify/2026-05-20_docs-post-adapter-state-sync_20260520t081618z.json`.
+- Current focus: Use the issue `#12` remaining-scope review to keep the next citation-verify adapter child narrow.
 - Hot files: `README.md`, `CLAUDE.md`, `docs/heartbeat.md`, `docs/HANDOFF.md`, `docs/repo-brief.md`, `docs/ROADMAP.md`, `docs/V2_EVIDENCE_SCHEMA.md`, `docs/V2_RELEASE_RUBRIC.md`, `docs/ISSUE_27_RELEASE_EVIDENCE_REVIEW_GUIDE.md`, `docs/SESSION_LOG.md`
-- Blockers: None for the docs-only current-state sync.
+- Blockers: None for issue `#12` citation-verify adapter scoping.
 - Do not touch this sprint: API framework, background queue, database, auth, dashboard, UI design, repo rename, broad product rewrites, placeholder V2 directories as live runtime, dependency churn without approval.
 - Related repos: None documented in-repo; treat this repo as the working source of truth.
-- Latest session log: `docs/SESSION_LOG.md` session 130
-- Next best task: Either scope a citation-verify evidence adapter as the next narrow issue `#12` slice, or pause and review remaining issue `#12` status before another adapter. Do not treat the landed adapters as completion of the full evidence/provenance graph or as Beta-ready, Pilot-ready, production-ready, or a shipped web app.
+- Latest session log: `docs/SESSION_LOG.md` session 131
+- Next best task: Open or implement a narrow citation-verify evidence adapter child for issue `#12`, using the remaining-scope review as the boundary. Do not treat the landed adapters as completion of the full evidence/provenance graph or as Beta-ready, Pilot-ready, production-ready, or a shipped web app.
 - Owner: Not explicitly named in-repo; maintained for the Merlin Law Group demo effort.


### PR DESCRIPTION
## Summary

- Adds a docs-only issue #101 review of remaining issue #12 evidence/provenance scope after the landed caselaw, carrier, and weather evidence-adapter slices.
- Documents that weather, carrier, and caselaw adapters are landed, while citation verification is the remaining evidence-producing source family without a named canonical adapter seam.
- Recommends the next narrow child issue: add a citation-verify evidence adapter over current `CitationVerifyPack` output.

## Changed files

- `docs/ISSUE_12_REMAINING_SCOPE.md`
- `docs/HANDOFF.md`
- `docs/heartbeat.md`
- `docs/SESSION_LOG.md`

## Validation

- `git diff --check`
- `python -m pytest -q` -> `449 passed in 11.69s`

## Not added

No runtime code, adapter implementation, dedupe, persistence, UI, API, live retrieval, AI scoring, full V2 evidence graph claim, or readiness claim was added.

## Recommended next task

Create or implement the citation-verify evidence adapter child issue: `Add citation-verify evidence adapter over current CitationVerifyPack output`.

Closes #101