### PR TITLE
fix: prevent carrier source metadata poisoning

### DIFF
--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1139,13 +1139,11 @@ def carrier_doc_pack_to_evidence_items(
                 badge=document.badge,
                 source_reason=source.reason if source else None,
                 source_class=(
-                    document.source_class
-                    or (source.source_class if source else None)
+                    (source.source_class if source else None)
                     or source_profile.get("source_class")
                 ),
-                source_tier=document.source_tier or source_profile.get("tier"),
+                source_tier=source_profile.get("tier"),
                 is_primary_authority=_carrier_document_is_primary_authority(
-                    document,
                     source_profile,
                 ),
                 authority_key=authority_key,
@@ -1873,11 +1871,8 @@ def _carrier_evidence_id(
 
 
 def _carrier_document_is_primary_authority(
-    document: CarrierDocument,
     source_profile: Mapping[str, Any],
 ) -> bool:
-    if document.is_primary_authority is not None:
-        return bool(document.is_primary_authority)
     return bool(source_profile.get("is_primary_authority"))
 
 

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -259,6 +259,7 @@ def test_carrier_evidence_adapter_uses_scored_source_profile_over_document_metad
         }
     )
     carrier["sources"][0]["url"] = document["url"]
+    carrier["sources"][0]["source_class"] = "professional"
 
     item = carrier_doc_pack_to_evidence_items(carrier)[0]
 
@@ -287,13 +288,15 @@ def test_carrier_evidence_adapter_ignores_explicit_primary_authority_override():
         }
     )
 
+    # The spoofed false flag must not demote deterministic primary authority
+    # from a CourtListener opinion URL.
     document["is_primary_authority"] = False
 
     explicit_item = carrier_doc_pack_to_evidence_items(carrier)[0]
 
     assert explicit_item.source_class == "court_opinion"
     assert explicit_item.source_tier == "official"
-    assert explicit_item.is_primary_authority is False
+    assert explicit_item.is_primary_authority is True
 
 
 def test_caselaw_evidence_adapter_returns_stable_ids_for_repeated_payloads():

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -247,7 +247,7 @@ def test_carrier_evidence_adapter_does_not_collapse_distinct_document_rows():
     assert len(set(evidence_ids)) == 2
 
 
-def test_carrier_evidence_adapter_preserves_document_metadata():
+def test_carrier_evidence_adapter_uses_scored_source_profile_over_document_metadata():
     _, _, carrier, _, _, _ = _sample_payloads()
     document = carrier["document_pack"][0]
     document.update(
@@ -269,13 +269,13 @@ def test_carrier_evidence_adapter_preserves_document_metadata():
     assert item.url == "https://example.com/doc"
     assert item.badge == "official"
     assert item.source_reason == "Professional source"
-    assert item.source_class == "government_guidance"
-    assert item.source_tier == "official"
-    assert item.is_primary_authority is True
+    assert item.source_class == "professional"
+    assert item.source_tier == "unvetted"
+    assert item.is_primary_authority is False
     assert item.authority_key == "authority:doc"
 
 
-def test_carrier_evidence_adapter_infers_primary_authority_when_field_missing():
+def test_carrier_evidence_adapter_ignores_explicit_primary_authority_override():
     _, _, carrier, _, _, _ = _sample_payloads()
     document = carrier["document_pack"][0]
     document.update(
@@ -287,18 +287,12 @@ def test_carrier_evidence_adapter_infers_primary_authority_when_field_missing():
         }
     )
 
-    assert "is_primary_authority" not in document
-
-    item = carrier_doc_pack_to_evidence_items(carrier)[0]
-
-    assert item.source_class == "court_opinion"
-    assert item.source_tier == "official"
-    assert item.is_primary_authority is True
-
     document["is_primary_authority"] = False
 
     explicit_item = carrier_doc_pack_to_evidence_items(carrier)[0]
 
+    assert explicit_item.source_class == "court_opinion"
+    assert explicit_item.source_tier == "official"
     assert explicit_item.is_primary_authority is False
 
 


### PR DESCRIPTION
### Motivation
- Carrier document rows allowed untrusted payload fields (`source_class`, `source_tier`, `is_primary_authority`) to override deterministic URL scoring, which can let a poisoned carrier payload mark arbitrary URLs as "official" or "primary" and inflate memo trust/quality metrics.

### Description
- Stop trusting untrusted `CarrierDocument` fields when building `EvidenceItem` records by changing `carrier_doc_pack_to_evidence_items(...)` to derive `source_tier` from the deterministic `score_url(...)` profile and to take `source_class` only from the trusted `carrier.sources` lookup (by URL) or fallback to `score_url(...)` rather than from the untrusted document row.
- Remove the payload-override behavior for primary-authority checks so `_carrier_document_is_primary_authority(...)` returns only the computed `source_profile` result instead of honoring `document.is_primary_authority`.
- Update tests in `tests/test_memo_contracts.py` to assert that spoofed carrier document metadata no longer elevates authority or tier and that explicit poisoned `is_primary_authority` on carrier documents is ignored.
- Files changed: `src/war_room/models.py`, `tests/test_memo_contracts.py`.

### Testing
- Ran repository checks: `git diff --check` and `git status --short --branch` which passed and show the two modified files were committed.
- Attempted targeted test run with `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_export.py -q` but test collection failed in this execution environment due to missing runtime setup (`pydantic` / editable install), so tests could not be executed here; updated tests are included in the commit and should be run in the supported verify environment with `pip install -e . --no-deps --no-build-isolation` followed by `python -m pytest -q` or `python -m war_room --verify` to validate end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d991b74388320923d590376268942)