### PR TITLE
[codex] Add citation-verify evidence adapter

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2927,8 +2927,9 @@ Status: Complete
     citation-verify adapter instead of building citation evidence rows inline.
   - Replaced positional citation evidence IDs such as `citation-check-1` with
     deterministic provenance-oriented IDs based on citation, authority,
-    source URL, status, badge, trust metadata, primary-authority signal, and a
-    short digest, with deterministic suffixing for duplicate check rows.
+    source URL, status, badge, existing `EvidenceItem` trust fields,
+    primary-authority signal, and a short digest, with deterministic suffixing
+    for duplicate check rows.
   - Added focused tests for stable IDs, duplicate suffixing, distinct rows,
     existing-field metadata preservation, sparse metadata, audit-snapshot
     inclusion, Evidence Board rendering, and export evidence-index output.
@@ -2951,3 +2952,35 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `454 passed in 32.16s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-103-citation-verify-evidence-adapter_20260520t131837z.json`.
+
+## Session 134 - PR 105 Citation Evidence ID Hardening Follow-Up
+Date: 2026-05-20
+Status: Complete
+
+- Applied the final PR `#105` ID-hardening follow-up for the issue `#103`
+  citation-verify evidence adapter.
+- What changed:
+  - Removed citation-check `note` prose from the
+    `_citation_check_evidence_id(...)` digest inputs in
+    `src/war_room/models.py`.
+  - Added a focused regression test proving citation evidence IDs stay stable
+    when only `CitationCheck.note` copy changes.
+  - Tightened the prior session-log wording so it names existing
+    `EvidenceItem` trust fields rather than implying free-text trust prose is
+    part of the ID basis.
+- Decisions added:
+  - Citation evidence IDs are no longer sensitive to citation-check note
+    wording.
+- Decisions not added:
+  - no `EvidenceItem` schema fields, citation verification behavior, status
+    vocabulary, live retrieval, badge/display semantics, adapter scope,
+    dependencies, full evidence graph, persistence, API framework, dashboard,
+    frontend, or readiness claim was added.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_export.py tests/test_issue_workspace.py -q`
+    -> `56 passed in 7.95s`.
+  - `python -m pytest -q` -> `455 passed in 27.21s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `455 passed in 27.98s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-103-citation-verify-evidence-adapter_20260520t134426z.json`.

--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -2913,3 +2913,41 @@ Status: Complete
 - Validation:
   - `git diff --check` -> passed.
   - `python -m pytest -q` -> `449 passed in 32.05s`.
+
+## Session 133 - Issue 103 Citation-Verify Evidence Adapter
+Date: 2026-05-20
+Status: Complete
+
+- Implemented issue `#103` as the next narrow issue `#12` evidence-adapter
+  slice over current `CitationVerifyPack` output.
+- What changed:
+  - Added `citation_verify_pack_to_evidence_items(...)` in
+    `src/war_room/models.py`.
+  - Routed `run_audit_snapshot_from_memo_input(...)` through the named
+    citation-verify adapter instead of building citation evidence rows inline.
+  - Replaced positional citation evidence IDs such as `citation-check-1` with
+    deterministic provenance-oriented IDs based on citation, authority,
+    source URL, status, badge, trust metadata, primary-authority signal, and a
+    short digest, with deterministic suffixing for duplicate check rows.
+  - Added focused tests for stable IDs, duplicate suffixing, distinct rows,
+    existing-field metadata preservation, sparse metadata, audit-snapshot
+    inclusion, Evidence Board rendering, and export evidence-index output.
+- Decisions added:
+  - Citation evidence rows now use the same named-adapter pattern as the
+    landed weather, carrier, and caselaw evidence adapters.
+- Decisions not added:
+  - no `EvidenceItem` schema fields, citation-search behavior, live retrieval,
+    citation-verification hardening, status vocabulary, badge/display
+    semantics, dedupe engine, database, persistence, full V2 evidence graph,
+    API framework, frontend, dashboard, app shell, auth, queues, workers, AI
+    scoring, generative behavior, readiness-level change, Beta-ready claim,
+    Pilot-ready claim, production-ready claim, or legal-product claim was
+    added.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_export.py tests/test_issue_workspace.py -q`
+    -> `55 passed in 9.84s`.
+  - `python -m pytest -q` -> `454 passed in 32.12s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `454 passed in 32.16s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-103-citation-verify-evidence-adapter_20260520t131837z.json`.

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1208,6 +1208,48 @@ def caselaw_pack_to_evidence_items(
     return evidence_items
 
 
+def citation_verify_pack_to_evidence_items(
+    payload: Mapping[str, Any] | CitationVerifyPack,
+) -> list[EvidenceItem]:
+    """Adapt current citation-verify output into canonical evidence items."""
+    citecheck = adapt_citation_verify_pack(payload)
+    evidence_items: list[EvidenceItem] = []
+    used_evidence_ids: dict[str, int] = {}
+
+    for index, check in enumerate(citecheck.checks, 1):
+        normalized_citation = _normalize_citation_value(check.citation)
+        authority_key = _authority_key_from_parts(
+            citation=normalized_citation,
+            title=check.case_name,
+            url=check.source_url,
+        )
+        evidence_items.append(
+            EvidenceItem(
+                evidence_id=_citation_check_evidence_id(
+                    check=check,
+                    normalized_citation=normalized_citation,
+                    authority_key=authority_key,
+                    used_evidence_ids=used_evidence_ids,
+                ),
+                module="citation_verify",
+                evidence_type="citation_check",
+                title=check.case_name or check.citation or f"Citation Check {index}",
+                summary=check.note,
+                url=check.source_url,
+                badge=check.badge,
+                source_reason=check.status,
+                source_class=check.source_class,
+                source_tier=check.source_tier,
+                is_primary_authority=check.is_primary_authority,
+                authority_key=authority_key,
+                citation=normalized_citation,
+                review_required=check.status != "verified",
+            )
+        )
+
+    return evidence_items
+
+
 def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditSnapshot:
     """Build a canonical audit snapshot from normalized memo-render input."""
     weather_payload = weather_brief_to_payload(memo_input.weather)
@@ -1247,39 +1289,11 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
         item.evidence_id for item in caselaw_evidence_items
     )
 
-    for index, check in enumerate(citecheck_payload.get("checks", []), 1):
-        evidence_id = f"citation-check-{index}"
-        has_source_url = bool(check.get("source_url"))
-        normalized_citation = _normalize_citation_value(check.get("citation"))
-        source_profile = score_url(
-            check.get("source_url") or "",
-            check.get("case_name") or check.get("citation") or f"Citation Check {index}",
-        )
-        evidence_items.append(
-            EvidenceItem(
-                evidence_id=evidence_id,
-                module="citation_verify",
-                evidence_type="citation_check",
-                title=check.get("case_name") or check.get("citation") or f"Citation Check {index}",
-                summary=check.get("note", ""),
-                url=check.get("source_url"),
-                badge=check.get("badge", ""),
-                source_reason=check.get("status"),
-                source_class=check.get("source_class") or (source_profile.get("source_class") if has_source_url else None),
-                source_tier=check.get("source_tier") or (source_profile.get("tier") if has_source_url else None),
-                is_primary_authority=bool(
-                    check.get("is_primary_authority", source_profile.get("is_primary_authority")) if has_source_url else False
-                ),
-                authority_key=_authority_key_from_parts(
-                    citation=normalized_citation,
-                    title=check.get("case_name"),
-                    url=check.get("source_url"),
-                ),
-                citation=normalized_citation,
-                review_required=check.get("status") != "verified",
-            )
-        )
-        evidence_ids_by_module["citation_verify"].append(evidence_id)
+    citation_evidence_items = citation_verify_pack_to_evidence_items(memo_input.citecheck)
+    evidence_items.extend(citation_evidence_items)
+    evidence_ids_by_module["citation_verify"].extend(
+        item.evidence_id for item in citation_evidence_items
+    )
 
     evidence_clusters = _build_evidence_clusters(evidence_items)
     quality_snapshot = _build_quality_snapshot(evidence_items, evidence_clusters, citecheck_payload)
@@ -1897,6 +1911,44 @@ def _caselaw_evidence_id(
     display_token = _stable_token(normalized_citation or case.name or authority_key or case.url)
     display_token = display_token[:48].rstrip("-") or "case"
     base_id = f"caselaw-case-{display_token}-{digest}"
+    collision_count = used_evidence_ids.get(base_id, 0) + 1
+    used_evidence_ids[base_id] = collision_count
+    if collision_count == 1:
+        return base_id
+    return f"{base_id}-{collision_count}"
+
+
+def _citation_check_evidence_id(
+    *,
+    check: CitationCheck,
+    normalized_citation: str | None,
+    authority_key: str | None,
+    used_evidence_ids: dict[str, int],
+) -> str:
+    identity_parts = [
+        authority_key or "",
+        normalized_citation or "",
+        _normalize_authority_name(check.case_name),
+        _normalize_cluster_url(check.source_url or ""),
+        _normalize_authority_name(check.status),
+        _normalize_authority_name(check.badge),
+        _normalize_authority_name(check.source_class),
+        _normalize_authority_name(check.source_tier),
+        "primary" if check.is_primary_authority else "secondary",
+        _normalize_authority_name(check.note),
+    ]
+    digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[
+        :10
+    ]
+    display_token = _stable_token(
+        normalized_citation
+        or check.case_name
+        or check.source_url
+        or check.status
+        or check.badge
+    )
+    display_token = display_token[:48].rstrip("-") or "citation"
+    base_id = f"citation-check-{display_token}-{digest}"
     collision_count = used_evidence_ids.get(base_id, 0) + 1
     used_evidence_ids[base_id] = collision_count
     if collision_count == 1:

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1935,7 +1935,6 @@ def _citation_check_evidence_id(
         _normalize_authority_name(check.source_class),
         _normalize_authority_name(check.source_tier),
         "primary" if check.is_primary_authority else "secondary",
-        _normalize_authority_name(check.note),
     ]
     digest = hashlib.sha256("\x1f".join(identity_parts).encode("utf-8")).hexdigest()[
         :10

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -18,6 +18,7 @@ from war_room.models import (
     adapt_evidence_board,
     carrier_doc_pack_to_evidence_items,
     caselaw_pack_to_evidence_items,
+    citation_verify_pack_to_evidence_items,
     evidence_board_to_payload,
     run_audit_snapshot_from_parts,
     weather_brief_to_evidence_items,
@@ -196,6 +197,9 @@ def test_evidence_board_payload_round_trips_with_schema_version():
     weather_evidence_id = weather_brief_to_evidence_items(parts[1])[0].evidence_id
     carrier_evidence_id = carrier_doc_pack_to_evidence_items(parts[2])[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(parts[3])[0].evidence_id
+    citation_evidence_id = (
+        citation_verify_pack_to_evidence_items(parts[4])[0].evidence_id
+    )
     board = build_evidence_board_from_parts(*parts)
 
     payload = evidence_board_to_payload(board)
@@ -209,6 +213,7 @@ def test_evidence_board_payload_round_trips_with_schema_version():
     assert weather_evidence_id in rendered
     assert carrier_evidence_id in rendered
     assert caselaw_evidence_id in rendered
+    assert citation_evidence_id in rendered
 
 
 def test_evidence_board_contract_rejects_unexpected_nested_fields():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -7,7 +7,7 @@ from war_room.carrier_module import build_carrier_doc_pack
 from war_room.caselaw_module import build_caselaw_pack
 from war_room.citation_verify import spot_check_citations
 from war_room.export_md import render_markdown_memo, write_markdown
-from war_room.models import CaseIntake, QuerySpec
+from war_room.models import CaseIntake, QuerySpec, citation_verify_pack_to_evidence_items
 from war_room.query_plan import generate_query_plan
 from war_room.weather_module import build_weather_brief
 
@@ -334,12 +334,17 @@ def test_render_surfaces_claim_cluster_references():
 
 
 def test_render_includes_canonical_evidence_index_rows():
-    md = render_markdown_memo(*_sample_data())
+    sample_data = _sample_data()
+    citation_evidence_id = (
+        citation_verify_pack_to_evidence_items(sample_data[4])[0].evidence_id
+    )
+    md = render_markdown_memo(*sample_data)
 
     assert "weather-source-nws-report-" in md
     assert "carrier-document-denial-" in md
     assert "caselaw-case-123-so-3d-456-" in md
-    assert "citation-check-1" in md
+    assert citation_evidence_id in md
+    assert "| citation-check-1 |" not in md
 
 
 def test_render_accepts_dict_intake_and_query_specs():

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -10,6 +10,7 @@ from war_room.models import (
     adapt_citation_verify_pack,
     carrier_doc_pack_to_evidence_items,
     caselaw_pack_to_evidence_items,
+    citation_verify_pack_to_evidence_items,
     citation_verify_pack_to_payload,
     memo_render_input_from_parts,
     run_audit_snapshot_from_parts,
@@ -413,6 +414,117 @@ def test_citation_verify_pack_adapter_backfills_sparse_trust_metadata():
     assert check.confidence == "medium"
 
 
+def test_citation_verify_evidence_adapter_returns_stable_provenance_ids():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+
+    first_ids = [
+        item.evidence_id for item in citation_verify_pack_to_evidence_items(citecheck)
+    ]
+    second_ids = [
+        item.evidence_id for item in citation_verify_pack_to_evidence_items(citecheck)
+    ]
+
+    assert first_ids == second_ids
+    assert first_ids[0].startswith("citation-check-123-so-3d-456-")
+    assert first_ids[0] != "citation-check-1"
+
+
+def test_citation_verify_evidence_adapter_does_not_collapse_distinct_check_rows():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"].append(
+        {
+            "badge": "warning",
+            "case_name": "Roe v. Ins",
+            "citation": "123 So.3d 456",
+            "status": "uncertain",
+            "note": "Same citation, distinct citation-check row.",
+            "source_url": "https://example.com/roe-case",
+        }
+    )
+    citecheck["summary"] = {"total": 2, "verified": 1, "uncertain": 1, "not_found": 0}
+
+    evidence_ids = [
+        item.evidence_id for item in citation_verify_pack_to_evidence_items(citecheck)
+    ]
+
+    assert len(evidence_ids) == 2
+    assert len(set(evidence_ids)) == 2
+
+
+def test_citation_verify_evidence_adapter_suffixes_duplicate_check_rows():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"].append(dict(citecheck["checks"][0]))
+    citecheck["summary"] = {"total": 2, "verified": 2, "uncertain": 0, "not_found": 0}
+
+    evidence_ids = [
+        item.evidence_id for item in citation_verify_pack_to_evidence_items(citecheck)
+    ]
+    base_id = evidence_ids[0]
+
+    assert evidence_ids == [base_id, f"{base_id}-2"]
+
+
+def test_citation_verify_evidence_adapter_preserves_existing_metadata_fields():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"][0].update(
+        {
+            "badge": "official",
+            "source_url": "https://www.flcourts.gov/case/123",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+            "status_reason": "official_citation_match",
+            "trust_explanation": "Not an EvidenceItem field.",
+            "confidence": "high",
+        }
+    )
+
+    item = citation_verify_pack_to_evidence_items(citecheck)[0]
+
+    assert item.module == "citation_verify"
+    assert item.evidence_type == "citation_check"
+    assert item.title == "Doe v. Ins"
+    assert item.summary == "Found on official source"
+    assert item.url == "https://www.flcourts.gov/case/123"
+    assert item.badge == "official"
+    assert item.source_reason == "verified"
+    assert item.source_class == "court_opinion"
+    assert item.source_tier == "official"
+    assert item.is_primary_authority is True
+    assert item.citation == "123 so. 3d 456"
+    assert item.authority_key == "citation:123 so. 3d 456"
+    assert item.review_required is False
+    assert "status_reason" not in item.model_dump()
+    assert "trust_explanation" not in item.model_dump()
+    assert "confidence" not in item.model_dump()
+
+
+def test_citation_verify_evidence_adapter_handles_sparse_metadata_safely():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"] = [
+        {
+            "badge": "not_found",
+            "status": "not_found",
+            "note": "No results found.",
+        }
+    ]
+    citecheck["summary"] = {"total": 1, "verified": 0, "uncertain": 0, "not_found": 1}
+
+    item = citation_verify_pack_to_evidence_items(citecheck)[0]
+
+    assert item.evidence_id.startswith("citation-check-not-found-")
+    assert item.title == "Citation Check 1"
+    assert item.summary == "No results found."
+    assert item.url is None
+    assert item.source_reason == "not_found"
+    assert item.source_class is None
+    assert item.source_tier is None
+    assert item.is_primary_authority is False
+    assert item.authority_key is None
+    assert item.citation is None
+    assert item.review_required is True
+
+
 def test_citation_verify_summary_validation_rejects_bad_totals():
     _, _, _, _, citecheck, _ = _sample_payloads()
     citecheck["summary"] = {"total": 99, "verified": 1, "uncertain": 0, "not_found": 0}
@@ -444,6 +556,7 @@ def test_run_audit_snapshot_builds_canonical_entities():
     weather_evidence_id = weather_brief_to_evidence_items(weather)[0].evidence_id
     carrier_evidence_id = carrier_doc_pack_to_evidence_items(carrier)[0].evidence_id
     caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
+    citation_evidence_id = citation_verify_pack_to_evidence_items(citecheck)[0].evidence_id
 
     snapshot = run_audit_snapshot_from_parts(
         intake,
@@ -486,6 +599,11 @@ def test_run_audit_snapshot_builds_canonical_entities():
         item.evidence_id == caselaw_evidence_id and item.module == "caselaw"
         for item in snapshot.evidence_items
     )
+    assert any(
+        item.evidence_id == citation_evidence_id and item.module == "citation_verify"
+        for item in snapshot.evidence_items
+    )
+    assert citation_evidence_id in snapshot.memo_claims[3].evidence_ids
     assert payload["evidence_clusters"][0]["cluster_id"] == "cluster-1"
     assert payload["evidence_clusters"][2]["cluster_type"] == "citation"
     assert snapshot.memo_claims[0].cluster_ids == ["cluster-1"]
@@ -595,9 +713,14 @@ def test_run_audit_snapshot_scopes_citation_review_events_to_non_verified_checks
         query_plan,
     )
 
-    citation_event = next(event for event in snapshot.review_events if event.event_id == "citation-uncertain")
+    citation_event = next(
+        event
+        for event in snapshot.review_events
+        if event.event_id == "citation-uncertain"
+    )
+    citation_evidence_id = citation_verify_pack_to_evidence_items(citecheck)[1].evidence_id
 
-    assert citation_event.related_evidence_ids == ["citation-check-2"]
+    assert citation_event.related_evidence_ids == [citation_evidence_id]
     assert citation_event.related_cluster_ids == ["cluster-4"]
     verified_cluster = next(cluster for cluster in snapshot.evidence_clusters if cluster.cluster_id == "cluster-3")
     uncertain_cluster = next(cluster for cluster in snapshot.evidence_clusters if cluster.cluster_id == "cluster-4")

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -1,5 +1,7 @@
 """Tests for typed citation/export contracts (issue #6 slice 3)."""
 
+import copy
+
 import pytest
 from pydantic import ValidationError
 
@@ -427,6 +429,19 @@ def test_citation_verify_evidence_adapter_returns_stable_provenance_ids():
     assert first_ids == second_ids
     assert first_ids[0].startswith("citation-check-123-so-3d-456-")
     assert first_ids[0] != "citation-check-1"
+
+
+def test_citation_verify_evidence_adapter_ids_ignore_note_copy_edits():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    edited_citecheck = copy.deepcopy(citecheck)
+    edited_citecheck["checks"][0]["note"] = (
+        "Found on official source; attorney should verify before relying on it."
+    )
+
+    original_id = citation_verify_pack_to_evidence_items(citecheck)[0].evidence_id
+    edited_id = citation_verify_pack_to_evidence_items(edited_citecheck)[0].evidence_id
+
+    assert edited_id == original_id
 
 
 def test_citation_verify_evidence_adapter_does_not_collapse_distinct_check_rows():


### PR DESCRIPTION
## Summary

- Added `citation_verify_pack_to_evidence_items(...)` over the current `CitationVerifyPack` / `CitationCheck` output.
- Routed `run_audit_snapshot_from_memo_input(...)` through the named citation-verify adapter instead of building citation evidence rows inline.
- Replaced positional citation evidence IDs with deterministic provenance-oriented IDs and deterministic duplicate-row suffixing.

## Tests added/updated

- Added focused adapter tests for stable IDs, distinct rows, duplicate suffixing, existing-field metadata preservation, sparse citation metadata, and audit-snapshot inclusion.
- Updated downstream Evidence Board and export tests to assert the new citation evidence IDs remain compatible with current rendering/output surfaces.

## Validation

- `git diff --check`
- `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_export.py tests/test_issue_workspace.py -q` -> `55 passed in 9.84s`
- `python -m pytest -q` -> `454 passed in 32.12s`
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `454 passed in 32.16s`

## Boundary notes

- `EvidenceItem` schema was not expanded.
- Citation verification behavior, live retrieval behavior, and citation status vocabulary were not changed.
- No badge/display semantic changes, dedupe engine, persistence layer, UI, dashboard, API framework, or full V2 evidence graph claim was added.

Closes #103