### PR TITLE
[codex] Add deterministic evidence dedupe helper

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3021,3 +3021,35 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `455 passed in 17.05s`; verify manifest written under
     `runs/verify/2026-05-20_docs-post-citation-verify-adapter-sync_20260520t140227z.json`.
+
+## Session 136 - PR 108 Deterministic Evidence Dedupe Helper Follow-Up
+Date: 2026-05-20
+Status: Complete
+
+- Applied the PR `#108` pre-merge review cleanup for the issue `#107`
+  deterministic evidence dedupe helper.
+- What changed:
+  - Added this session-log entry for the helper-only issue `#107` slice.
+  - Tightened the `dedupe_evidence_items(...)` docstring and internal helper
+    naming so the helper only claims selected review/provenance compatibility
+    fields checked by this helper, not all provenance fields.
+  - Made the same-key summary policy explicit in the URL-dedupe regression
+    test: when two rows collapse by a strong normalized URL key and differ
+    only in `summary`, the retained first row wins and the candidate summary
+    is not merged into it.
+- Decisions added:
+  - Current helper-only dedupe keeps the retained `EvidenceItem` row unchanged;
+    it does not merge candidate summary text into the retained row.
+- Decisions not added:
+  - no audit snapshot assembly integration, old-id to retained-id remapping,
+    `EvidenceItem` schema expansion, persistence, UI, API, dashboard,
+    runtime behavior change, live retrieval, fuzzy/ML clustering, AI scoring,
+    readiness claim, or broad issue `#12` dedupe engine was added.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest tests/test_memo_contracts.py -q`
+    -> `37 passed in 1.17s`.
+  - `python -m pytest -q` -> `462 passed in 27.70s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `462 passed in 23.81s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-issue-107-deterministic-evidence-dedupe_20260520t150120z.json`.

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -6,7 +6,7 @@ import datetime as dt
 import hashlib
 import re
 from typing import Any, Literal, Mapping, Sequence
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from war_room.orchestration import (
@@ -23,6 +23,7 @@ MemoSectionStatus = Literal["draft", "review_required", "ready"]
 LegalIssueStatus = Literal["open", "review_required", "resolved"]
 RunEventSeverity = Literal["info", "warning", "error"]
 RetrievalTaskStatus = Literal["queued", "running", "completed", "failed", "degraded", "cancelled"]
+_TRACKING_QUERY_PARAMS = {"fbclid", "gclid", "dclid", "mc_cid", "mc_eid", "igshid"}
 
 
 def _validate_schema_version(value: str) -> str:
@@ -1250,6 +1251,32 @@ def citation_verify_pack_to_evidence_items(
     return evidence_items
 
 
+def dedupe_evidence_items(evidence_items: Sequence[EvidenceItem]) -> list[EvidenceItem]:
+    """Return a stable list with only clear duplicate evidence rows collapsed.
+
+    Key precedence is normalized URL, normalized citation/authority key, then a
+    module-scoped title fallback. A candidate row is only collapsed into an
+    earlier retained row when review and provenance fields remain compatible.
+    """
+    retained_by_key: dict[tuple[str, ...], list[EvidenceItem]] = {}
+    deduped: list[EvidenceItem] = []
+
+    for item in evidence_items:
+        key = _dedupe_key_for_evidence_item(item)
+        if key is None:
+            deduped.append(item)
+            continue
+
+        retained_items = retained_by_key.setdefault(key, [])
+        if any(_evidence_items_can_collapse(retained, item) for retained in retained_items):
+            continue
+
+        retained_items.append(item)
+        deduped.append(item)
+
+    return deduped
+
+
 def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditSnapshot:
     """Build a canonical audit snapshot from normalized memo-render input."""
     weather_payload = weather_brief_to_payload(memo_input.weather)
@@ -1963,6 +1990,173 @@ def _case_is_primary_authority(
     if "is_primary_authority" in case.model_fields_set:
         return bool(case.is_primary_authority)
     return bool(source_profile.get("is_primary_authority"))
+
+
+def _dedupe_key_for_evidence_item(item: EvidenceItem) -> tuple[str, ...] | None:
+    url_key = _normalize_evidence_url_key(item.url)
+    if url_key:
+        return ("url", url_key)
+
+    citation_key = _normalize_citation_value(item.citation)
+    if citation_key:
+        return ("citation", citation_key)
+
+    authority_key = _normalize_evidence_authority_key(item.authority_key)
+    if authority_key:
+        if authority_key.startswith("citation:"):
+            return ("citation", authority_key.removeprefix("citation:"))
+        if authority_key.startswith("url:"):
+            return ("url", authority_key.removeprefix("url:"))
+        return ("authority", authority_key)
+
+    title_key = _normalize_authority_name(item.title)
+    if title_key:
+        return ("title", item.module, item.evidence_type, title_key)
+    return None
+
+
+def _evidence_items_can_collapse(retained: EvidenceItem, candidate: EvidenceItem) -> bool:
+    compatible_text_fields = (
+        (
+            _normalize_evidence_url_key(retained.url),
+            _normalize_evidence_url_key(candidate.url),
+        ),
+        (
+            _normalize_citation_value(retained.citation) or "",
+            _normalize_citation_value(candidate.citation) or "",
+        ),
+        (
+            _normalize_evidence_authority_key(retained.authority_key) or "",
+            _normalize_evidence_authority_key(candidate.authority_key) or "",
+        ),
+        (
+            _normalize_optional_evidence_text(retained.badge),
+            _normalize_optional_evidence_text(candidate.badge),
+        ),
+        (
+            _normalize_optional_evidence_text(retained.source_reason),
+            _normalize_optional_evidence_text(candidate.source_reason),
+        ),
+        (
+            _normalize_optional_evidence_text(retained.source_class),
+            _normalize_optional_evidence_text(candidate.source_class),
+        ),
+        (
+            _normalize_optional_evidence_text(retained.source_tier),
+            _normalize_optional_evidence_text(candidate.source_tier),
+        ),
+        (
+            _normalize_optional_evidence_text(retained.issue),
+            _normalize_optional_evidence_text(candidate.issue),
+        ),
+    )
+    if not all(
+        _candidate_provenance_is_preserved(retained_value, candidate_value)
+        for retained_value, candidate_value in compatible_text_fields
+    ):
+        return False
+
+    return (
+        retained.is_primary_authority == candidate.is_primary_authority
+        and retained.review_required == candidate.review_required
+    )
+
+
+def _candidate_provenance_is_preserved(
+    retained_value: str,
+    candidate_value: str,
+) -> bool:
+    if not candidate_value:
+        return True
+    if not retained_value:
+        return False
+    return retained_value == candidate_value
+
+
+def _normalize_optional_evidence_text(value: str | None) -> str:
+    if not value:
+        return ""
+    normalized = re.sub(r"\s+", " ", value.strip().lower())
+    return normalized
+
+
+def _normalize_evidence_authority_key(value: str | None) -> str | None:
+    if not value:
+        return None
+
+    prefix, separator, raw_value = value.strip().partition(":")
+    if not separator:
+        normalized = _normalize_authority_name(value)
+        return normalized or None
+
+    normalized_prefix = _normalize_authority_name(prefix)
+    if normalized_prefix == "citation":
+        normalized_value = _normalize_citation_value(raw_value) or ""
+    elif normalized_prefix == "url":
+        normalized_value = _normalize_evidence_url_key(raw_value) or ""
+    elif normalized_prefix == "authority":
+        normalized_parts = [
+            _normalize_authority_name(part)
+            for part in raw_value.split("|")
+        ]
+        normalized_value = "|".join(part for part in normalized_parts if part)
+    else:
+        normalized_value = _normalize_authority_name(raw_value)
+
+    if not normalized_prefix or not normalized_value:
+        return None
+    return f"{normalized_prefix}:{normalized_value}"
+
+
+def _normalize_evidence_url_key(value: str | None) -> str:
+    if not value:
+        return ""
+
+    raw_url = value.strip()
+    if not raw_url:
+        return ""
+
+    parse_target = raw_url
+    if "://" not in parse_target and not parse_target.startswith("//"):
+        parse_target = f"//{parse_target}"
+
+    try:
+        parsed = urlparse(parse_target)
+    except Exception:
+        return raw_url.rstrip("/")
+
+    hostname = (parsed.hostname or "").lower().removeprefix("www.")
+    if not hostname:
+        return raw_url.rstrip("/")
+
+    netloc = hostname
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    if port and not (
+        (parsed.scheme == "http" and port == 80)
+        or (parsed.scheme == "https" and port == 443)
+    ):
+        netloc = f"{hostname}:{port}"
+
+    path = re.sub(r"/+", "/", (parsed.path or "").rstrip("/"))
+    normalized = f"{netloc}{path}".strip("/")
+
+    query_pairs = [
+        (name, query_value)
+        for name, query_value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not name.lower().startswith("utm_")
+        and name.lower() not in _TRACKING_QUERY_PARAMS
+    ]
+    if query_pairs:
+        sorted_query_pairs = sorted(
+            query_pairs,
+            key=lambda pair: (pair[0].lower(), pair[1]),
+        )
+        normalized = f"{normalized}?{urlencode(sorted_query_pairs)}"
+
+    return normalized
 
 
 def _cluster_key_for_item(item: EvidenceItem) -> tuple[str, str]:

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1256,7 +1256,8 @@ def dedupe_evidence_items(evidence_items: Sequence[EvidenceItem]) -> list[Eviden
 
     Key precedence is normalized URL, normalized citation/authority key, then a
     module-scoped title fallback. A candidate row is only collapsed into an
-    earlier retained row when review and provenance fields remain compatible.
+    earlier retained row when the selected review/provenance compatibility
+    fields checked by this helper remain compatible.
     """
     retained_by_key: dict[tuple[str, ...], list[EvidenceItem]] = {}
     deduped: list[EvidenceItem] = []
@@ -2016,7 +2017,7 @@ def _dedupe_key_for_evidence_item(item: EvidenceItem) -> tuple[str, ...] | None:
 
 
 def _evidence_items_can_collapse(retained: EvidenceItem, candidate: EvidenceItem) -> bool:
-    compatible_text_fields = (
+    selected_compatibility_fields = (
         (
             _normalize_evidence_url_key(retained.url),
             _normalize_evidence_url_key(candidate.url),
@@ -2051,8 +2052,8 @@ def _evidence_items_can_collapse(retained: EvidenceItem, candidate: EvidenceItem
         ),
     )
     if not all(
-        _candidate_provenance_is_preserved(retained_value, candidate_value)
-        for retained_value, candidate_value in compatible_text_fields
+        _candidate_compatibility_field_is_preserved(retained_value, candidate_value)
+        for retained_value, candidate_value in selected_compatibility_fields
     ):
         return False
 
@@ -2062,7 +2063,7 @@ def _evidence_items_can_collapse(retained: EvidenceItem, candidate: EvidenceItem
     )
 
 
-def _candidate_provenance_is_preserved(
+def _candidate_compatibility_field_is_preserved(
     retained_value: str,
     candidate_value: str,
 ) -> bool:

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -14,6 +14,7 @@ from war_room.models import (
     caselaw_pack_to_evidence_items,
     citation_verify_pack_to_evidence_items,
     citation_verify_pack_to_payload,
+    dedupe_evidence_items,
     memo_render_input_from_parts,
     run_audit_snapshot_from_parts,
     run_audit_snapshot_to_payload,
@@ -538,6 +539,189 @@ def test_citation_verify_evidence_adapter_handles_sparse_metadata_safely():
     assert item.authority_key is None
     assert item.citation is None
     assert item.review_required is True
+
+
+def test_dedupe_evidence_items_collapses_normalized_url_duplicates():
+    _, weather, _, _, _, _ = _sample_payloads()
+    weather["sources"][0]["url"] = "https://www.weather.gov/r/?utm_source=newsletter"
+    weather["sources"].append(
+        {
+            **weather["sources"][0],
+            "url": "https://weather.gov/r",
+        }
+    )
+    weather["key_observations"].append(weather["key_observations"][0])
+
+    items = weather_brief_to_evidence_items(weather)
+    deduped = dedupe_evidence_items(items)
+
+    assert len(items) == 2
+    assert [item.evidence_id for item in deduped] == [items[0].evidence_id]
+    assert deduped[0].url == "https://www.weather.gov/r/?utm_source=newsletter"
+    assert deduped[0].badge == items[0].badge
+    assert deduped[0].review_required is items[0].review_required
+
+
+def test_dedupe_evidence_items_uses_citation_key_when_url_is_absent():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"][0].pop("source_url", None)
+    citecheck["checks"][0]["status"] = "uncertain"
+    citecheck["checks"][0]["badge"] = "warning"
+    citecheck["checks"][0]["note"] = "Citation text needs manual review."
+    citecheck["checks"].append(dict(citecheck["checks"][0]))
+    citecheck["summary"] = {"total": 2, "verified": 0, "uncertain": 2, "not_found": 0}
+
+    items = citation_verify_pack_to_evidence_items(citecheck)
+    deduped = dedupe_evidence_items(items)
+
+    assert len(items) == 2
+    assert [item.evidence_id for item in deduped] == [items[0].evidence_id]
+    assert deduped[0].citation == "123 so. 3d 456"
+    assert deduped[0].source_reason == "uncertain"
+    assert deduped[0].review_required is True
+
+
+def test_dedupe_evidence_items_uses_module_scoped_title_fallback():
+    _, weather, _, _, _, _ = _sample_payloads()
+    item = weather_brief_to_evidence_items(weather)[0].model_copy(
+        update={
+            "evidence_id": "weather-title-fallback-1",
+            "url": None,
+            "authority_key": None,
+            "citation": None,
+        }
+    )
+    duplicate = item.model_copy(
+        update={
+            "evidence_id": "weather-title-fallback-2",
+            "summary": "Same title from a later row.",
+        }
+    )
+
+    deduped = dedupe_evidence_items([item, duplicate])
+
+    assert [row.evidence_id for row in deduped] == ["weather-title-fallback-1"]
+    assert deduped[0].summary == item.summary
+
+
+def test_dedupe_evidence_items_keeps_sparse_rows_without_clear_key():
+    _, _, _, _, citecheck, _ = _sample_payloads()
+    citecheck["checks"] = [
+        {
+            "badge": "not_found",
+            "status": "not_found",
+            "note": "No results found.",
+        }
+    ]
+    citecheck["summary"] = {"total": 1, "verified": 0, "uncertain": 0, "not_found": 1}
+    item = citation_verify_pack_to_evidence_items(citecheck)[0].model_copy(
+        update={
+            "evidence_id": "sparse-citation-row-1",
+            "title": "",
+            "url": None,
+            "authority_key": None,
+            "citation": None,
+        }
+    )
+    duplicate = item.model_copy(update={"evidence_id": "sparse-citation-row-2"})
+
+    deduped = dedupe_evidence_items([item, duplicate])
+
+    assert [row.evidence_id for row in deduped] == [
+        "sparse-citation-row-1",
+        "sparse-citation-row-2",
+    ]
+
+
+def test_dedupe_evidence_items_allows_conservative_cross_module_url_dedupe():
+    _, _, _, caselaw, citecheck, _ = _sample_payloads()
+    case_item = caselaw_pack_to_evidence_items(caselaw)[0].model_copy(
+        update={
+            "url": "https://www.flcourts.gov/case/123?utm_source=alert",
+            "badge": "official",
+            "source_reason": "official source",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+            "issue": None,
+        }
+    )
+    citation_item = citation_verify_pack_to_evidence_items(citecheck)[0].model_copy(
+        update={
+            "url": "https://flcourts.gov/case/123",
+            "badge": "official",
+            "source_reason": "official source",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+        }
+    )
+
+    deduped = dedupe_evidence_items([case_item, citation_item])
+
+    assert [row.evidence_id for row in deduped] == [case_item.evidence_id]
+
+
+def test_dedupe_evidence_items_does_not_cross_module_dedupe_title_fallback():
+    _, weather, carrier, _, _, _ = _sample_payloads()
+    weather_item = weather_brief_to_evidence_items(weather)[0].model_copy(
+        update={
+            "evidence_id": "weather-shared-title",
+            "title": "Shared evidence title",
+            "url": None,
+            "authority_key": None,
+            "citation": None,
+        }
+    )
+    carrier_item = carrier_doc_pack_to_evidence_items(carrier)[0].model_copy(
+        update={
+            "evidence_id": "carrier-shared-title",
+            "title": "Shared evidence title",
+            "url": None,
+            "authority_key": None,
+            "citation": None,
+        }
+    )
+
+    deduped = dedupe_evidence_items([weather_item, carrier_item])
+
+    assert [row.evidence_id for row in deduped] == [
+        "weather-shared-title",
+        "carrier-shared-title",
+    ]
+
+
+def test_dedupe_evidence_items_keeps_distinct_urls_and_review_conflicts():
+    _, _, carrier, _, _, _ = _sample_payloads()
+    base_item = carrier_doc_pack_to_evidence_items(carrier)[0]
+    first_url = base_item.model_copy(
+        update={
+            "evidence_id": "carrier-doc-id-1",
+            "url": "https://example.com/doc?id=1",
+        }
+    )
+    second_url = base_item.model_copy(
+        update={
+            "evidence_id": "carrier-doc-id-2",
+            "url": "https://example.com/doc?id=2",
+        }
+    )
+    review_required_duplicate = first_url.model_copy(
+        update={
+            "evidence_id": "carrier-doc-review-required",
+            "review_required": True,
+        }
+    )
+
+    deduped = dedupe_evidence_items(
+        [first_url, second_url, review_required_duplicate]
+    )
+
+    assert [row.evidence_id for row in deduped] == [
+        "carrier-doc-id-1",
+        "carrier-doc-id-2",
+        "carrier-doc-review-required",
+    ]
 
 
 def test_citation_verify_summary_validation_rejects_bad_totals():

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -550,14 +550,18 @@ def test_dedupe_evidence_items_collapses_normalized_url_duplicates():
             "url": "https://weather.gov/r",
         }
     )
-    weather["key_observations"].append(weather["key_observations"][0])
+    weather["key_observations"].append(
+        "Candidate-only summary should not be merged into the retained row."
+    )
 
     items = weather_brief_to_evidence_items(weather)
     deduped = dedupe_evidence_items(items)
 
     assert len(items) == 2
+    assert items[0].summary != items[1].summary
     assert [item.evidence_id for item in deduped] == [items[0].evidence_id]
     assert deduped[0].url == "https://www.weather.gov/r/?utm_source=newsletter"
+    assert deduped[0].summary == "Winds of 120 mph"
     assert deduped[0].badge == items[0].badge
     assert deduped[0].review_required is items[0].review_required
 


### PR DESCRIPTION
## Summary of helper added
- Added dedupe_evidence_items(...) over canonical EvidenceItem rows.
- The helper is local, deterministic, helper-only, and preserves the retained row unchanged.
- Collapse is conservative: rows with conflicting selected review/provenance compatibility fields checked by the helper stay separate.

## Keying strategy summary
- First key: normalized URL, including scheme-insensitive host normalization, www. removal, trailing-slash cleanup, query ordering, and tracking-query removal.
- Second key: normalized citation or authority key when URL is absent.
- Third key: normalized title plus module plus evidence_type when stronger identifiers are absent.
- Rows without a clear key remain distinct.

## Tests added/updated
- Added focused tests in `tests/test_memo_contracts.py` for URL dedupe, citation-key dedupe, title fallback, sparse metadata, conservative cross-module behavior, distinct URL rows, review-required conflicts, and same-key summary retention behavior.
- Tests use current weather, carrier, caselaw, and citation-verification evidence adapter rows.

## Review cleanup
- Added `docs/SESSION_LOG.md` entry for the issue #107 helper session.
- Narrowed helper wording so it does not claim all provenance fields are checked.
- Made current same-key behavior explicit: when two rows dedupe by a strong key and differ only in summary, the retained first row wins and the candidate summary is not merged.

## Validation results
- `git diff --check` passed.
- `python -m pytest tests/test_memo_contracts.py -q` passed: 37 passed.
- `python -m pytest -q` passed: 462 passed.
- `python -m war_room --verify` passed; embedded pytest reported 462 passed.

## Explicit non-goal note
No runtime integration, audit snapshot assembly integration, old_id -> retained_id remapping, schema expansion, persistence, live retrieval, provider-ranking changes, citation verification behavior changes, fuzzy/ML clustering, UI/API/dashboard, AI scoring, or readiness claim was added.

Closes #107