### PR TITLE
fix: require citation coverage before issue workspace marks ready

### DIFF
--- a/src/war_room/issue_workspace.py
+++ b/src/war_room/issue_workspace.py
@@ -70,8 +70,16 @@ def build_issue_workspace(
             for cluster_id in cluster_ids
             for event in events_by_cluster.get(cluster_id, [])
         )
-        review_required = bool(review_event_ids) or not candidates or any(
+        has_unverified_outcomes = any(
             outcome.status != "verified" for outcome in citation_outcomes
+        )
+        has_unchecked_candidates = len(candidates) > len(citation_outcomes)
+        review_required = (
+            bool(review_event_ids)
+            or not candidates
+            or not citation_outcomes
+            or has_unchecked_candidates
+            or has_unverified_outcomes
         )
         status = "review_required" if review_required else "ready"
         cards.append(

--- a/tests/test_issue_workspace.py
+++ b/tests/test_issue_workspace.py
@@ -236,3 +236,56 @@ def test_format_issue_workspace_surfaces_issue_status_and_authorities():
     assert "[ready] scope of repair" in rendered
     assert "Strongest authorities:" in rendered
     assert "Citation outcomes:" in rendered
+
+
+def test_build_issue_workspace_requires_review_when_no_citation_outcomes():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_parts()
+    citecheck["checks"] = []
+    citecheck["summary"] = {"total": 0, "verified": 0, "uncertain": 0, "not_found": 0}
+
+    workspace = build_issue_workspace_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    assert workspace.review_required_issue_count == 2
+    assert all(card.review_required for card in workspace.issue_cards)
+
+
+def test_build_issue_workspace_requires_review_when_citation_outcomes_are_partial():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_parts()
+    citecheck["checks"] = [
+        {
+            "badge": "verified",
+            "case_name": "Doe v. Ins",
+            "citation": "123 So.3d 456",
+            "status": "verified",
+            "note": "Found on reviewed source",
+            "source_url": "https://example.com/case",
+        }
+    ]
+    citecheck["summary"] = {"total": 1, "verified": 1, "uncertain": 0, "not_found": 0}
+
+    workspace = build_issue_workspace_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    cards_by_issue = {card.issue_label: card for card in workspace.issue_cards}
+
+    assert workspace.review_required_issue_count == 1
+    assert cards_by_issue["scope of repair"].review_required is True
+    assert cards_by_issue["scope of repair"].citation_outcomes == []
+    assert cards_by_issue["wind vs water causation"].review_required is False
+    assert [
+        outcome.status
+        for outcome in cards_by_issue["wind vs water causation"].citation_outcomes
+    ] == ["verified"]


### PR DESCRIPTION
### Motivation
- The issue-workspace readiness logic could mark issues as `ready` when case-law candidates existed but citation outcomes were missing or incomplete, which under-reports review-required state and leaks an integrity/trust-signal vulnerability.
- The change enforces that issues with legal authorities are not treated as ready unless citation outcomes exist and cover candidates and do not include non-verified statuses.

### Description
- Tightened `build_issue_workspace()` in `src/war_room/issue_workspace.py` to compute `has_unverified_outcomes` and `has_unchecked_candidates` and to mark an issue `review_required` when citation outcomes are missing, fewer than candidate authorities, or include non-`verified` statuses.
- Added two focused regression tests in `tests/test_issue_workspace.py` that assert issues become `review_required` when citation outcomes are (a) zero despite case candidates and (b) partial (fewer outcomes than candidates).
- Kept the change minimal and localized to readiness logic and tests only, preserving existing interfaces and no dependency or schema changes.

### Testing
- Ran `git diff --check`, which passed without whitespace issues.
- Executed the targeted pytest run `python -m pytest tests/test_issue_workspace.py -q` but test collection failed due to a missing environment dependency (`ModuleNotFoundError: No module named 'pydantic'`), so automated tests could not complete in this environment.
- Recommend local/full verification by bootstrapping the repo (`pip install -r requirements.txt` and editable install) and running `python -m war_room --verify` or `pytest -q` to confirm the new tests and full suite pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaaba0083209eac0d564ce5d1a3)