### PR TITLE
fix: harden dev orchestration HTTP adapter request handling

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3091,3 +3091,34 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `462 passed in 30.77s`; verify manifest written under
     `runs/verify/2026-05-20_docs-final-post-dedupe-helper-sync_20260520t151849z.json`.
+
+## Session 138 - PR 110 Oversized HTTP Request Test Hardening
+Date: 2026-05-20
+Status: Complete
+
+- Rebased PR `#110` onto latest `origin/main` and applied a narrow fix for
+  the CI-only oversized request upload failure.
+- What changed:
+  - Replaced the `urllib` oversized-body regression with a raw socket request
+    that declares `Content-Length > MAX_REQUEST_BODY_BYTES` without uploading a
+    large body.
+  - Kept the dev HTTP adapter's security behavior intact: oversized
+    `Content-Length` is rejected before `rfile.read(...)`.
+  - Normalized the loopback host helper for common local forms such as
+    uppercase `LOCALHOST`, trailing-dot `localhost.`, IPv6 loopback, and IPv4
+    shorthand loopback.
+- Decisions added:
+  - Oversized-body tests should exercise the pre-read `Content-Length` guard
+    without relying on high-level clients to complete a rejected upload.
+- Decisions not added:
+  - no production API framework, auth, rate limiting, request streaming layer,
+    dependency, persistence, queues, workers, dashboard, UI, or broader
+    orchestration behavior was added.
+- Validation:
+  - `python -m pytest tests/test_orchestration_http.py::test_request_body_too_large_returns_clear_json_error tests/test_orchestration_http.py::test_loopback_host_policy_accepts_common_loopback_forms -q`
+    -> `2 passed in 9.50s`.
+  - `python -m pytest tests/test_orchestration_http.py tests/test_orchestration_transport.py tests/test_orchestration_service.py -q`
+    -> `22 passed in 7.49s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `473 passed in 29.06s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-fix-unauthenticated-access-in-dev-http-adapter_20260520t165135z.json`.

--- a/src/war_room/orchestration_http.py
+++ b/src/war_room/orchestration_http.py
@@ -9,6 +9,7 @@ turning the repo into a production API service.
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import json
 from collections.abc import Mapping
 from http import HTTPStatus
@@ -48,6 +49,9 @@ class OrchestrationDevHTTPServer(ThreadingHTTPServer):
             OrchestrationDevHTTPRequestHandler,
             bind_and_activate=bind_and_activate,
         )
+
+
+MAX_REQUEST_BODY_BYTES = 1_048_576
 
 
 class OrchestrationDevHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -186,6 +190,16 @@ class OrchestrationDevHTTPRequestHandler(BaseHTTPRequestHandler):
                 message="Request body must contain a JSON object.",
             )
 
+        if content_length > MAX_REQUEST_BODY_BYTES:
+            return None, _http_error_payload(
+                operation=operation,
+                code="request_too_large",
+                message=(
+                    "Request body exceeds dev adapter limit of "
+                    f"{MAX_REQUEST_BODY_BYTES} bytes."
+                ),
+            )
+
         raw_body = self.rfile.read(content_length)
         try:
             decoded = raw_body.decode("utf-8")
@@ -224,8 +238,16 @@ def create_dev_http_server(
     *,
     service: InMemoryOrchestrationService | None = None,
     scenario_id: str | None = None,
+    allow_non_loopback: bool = False,
 ) -> OrchestrationDevHTTPServer:
     """Create a process-local dev server around the existing transport layer."""
+
+    host, _ = server_address
+    if not allow_non_loopback and not _is_loopback_host(host):
+        raise ValueError(
+            "Dev HTTP adapter only allows loopback hosts by default; "
+            "pass allow_non_loopback=True to override intentionally."
+        )
 
     return OrchestrationDevHTTPServer(
         server_address,
@@ -241,6 +263,11 @@ def main(argv: list[str] | None = None) -> int:
         description="Dev-only HTTP adapter for offline orchestration transport."
     )
     parser.add_argument("--host", default="127.0.0.1", help="Bind host for local dev use.")
+    parser.add_argument(
+        "--allow-non-loopback",
+        action="store_true",
+        help="Allow binding to non-loopback hosts (unsafe; dev-only).",
+    )
     parser.add_argument("--port", type=int, default=8765, help="Bind port for local dev use.")
     parser.add_argument(
         "--scenario-id",
@@ -252,6 +279,7 @@ def main(argv: list[str] | None = None) -> int:
     server = create_dev_http_server(
         (args.host, args.port),
         scenario_id=args.scenario_id,
+        allow_non_loopback=args.allow_non_loopback,
     )
     host, port = server.server_address
     print(
@@ -283,6 +311,16 @@ def main(argv: list[str] | None = None) -> int:
     finally:
         server.server_close()
     return 0
+
+
+def _is_loopback_host(host: str) -> bool:
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
 
 
 def _path_segments(path: str) -> list[str]:

--- a/src/war_room/orchestration_http.py
+++ b/src/war_room/orchestration_http.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import ipaddress
 import json
+import socket
 from collections.abc import Mapping
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -314,13 +315,17 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _is_loopback_host(host: str) -> bool:
-    if host == "localhost":
+    normalized = host.strip().lower().rstrip(".")
+    if normalized == "localhost":
         return True
     try:
-        return ipaddress.ip_address(host).is_loopback
+        return ipaddress.ip_address(normalized).is_loopback
     except ValueError:
+        pass
+    try:
+        return ipaddress.ip_address(socket.inet_aton(normalized)).is_loopback
+    except OSError:
         return False
-
 
 
 def _path_segments(path: str) -> list[str]:

--- a/tests/test_orchestration_http.py
+++ b/tests/test_orchestration_http.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import json
+import socket
 from pathlib import Path
 from threading import Thread
 from typing import Any
 from urllib.error import HTTPError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import pytest
 
 from war_room.models import CaseIntake
 from war_room.orchestration_api_contracts import StartRunRequest, start_run_request_to_payload
-from war_room.orchestration_http import MAX_REQUEST_BODY_BYTES, create_dev_http_server
+from war_room.orchestration_http import (
+    MAX_REQUEST_BODY_BYTES,
+    _is_loopback_host,
+    create_dev_http_server,
+)
 from war_room.orchestration_service import InMemoryOrchestrationService
 from war_room.scenarios import load_scenario
 
@@ -91,6 +97,44 @@ def _request(
         return exc.code, json.loads(exc.read().decode("utf-8"))
 
 
+def _raw_post_declaring_body_length(
+    base_url: str,
+    path: str,
+    content_length: int,
+) -> tuple[int, dict[str, Any]]:
+    parsed = urlparse(base_url)
+    if parsed.hostname is None or parsed.port is None:
+        raise AssertionError(f"Unexpected test server URL: {base_url}")
+
+    request = (
+        f"POST {path} HTTP/1.1\r\n"
+        f"Host: {parsed.hostname}:{parsed.port}\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {content_length}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("ascii")
+
+    chunks = []
+    with socket.create_connection((parsed.hostname, parsed.port), timeout=10) as client:
+        client.settimeout(10)
+        client.sendall(request)
+        try:
+            client.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+        while True:
+            chunk = client.recv(65536)
+            if not chunk:
+                break
+            chunks.append(chunk)
+
+    raw_response = b"".join(chunks)
+    header_bytes, _, body = raw_response.partition(b"\r\n\r\n")
+    status_line = header_bytes.splitlines()[0].decode("ascii")
+    return int(status_line.split()[1]), json.loads(body.decode("utf-8"))
+
+
 def test_health_route_returns_dev_only_json_envelope(http_base_url):
     status, body = _request(http_base_url, "GET", "/healthz")
 
@@ -161,26 +205,33 @@ def test_invalid_json_returns_http_error_with_transport_style_envelope(http_base
     assert body["status_presentation"] is None
 
 
-
-
 def test_request_body_too_large_returns_clear_json_error(http_base_url):
-    oversized = b"{" + (b" " * MAX_REQUEST_BODY_BYTES) + b"}"
-    status, body = _request(
+    status, body = _raw_post_declaring_body_length(
         http_base_url,
-        "POST",
         "/runs",
-        raw_body=oversized,
+        MAX_REQUEST_BODY_BYTES + 1,
     )
 
     assert status == 400
     assert body["ok"] is False
     assert body["operation"] == "start_run"
+    assert body["payload"]["status"] == "error"
     assert body["payload"]["error"]["code"] == "request_too_large"
+    assert body["status_presentation"] is None
+
+
+def test_loopback_host_policy_accepts_common_loopback_forms():
+    assert _is_loopback_host("LOCALHOST") is True
+    assert _is_loopback_host("localhost.") is True
+    assert _is_loopback_host("127.1") is True
+    assert _is_loopback_host("::1") is True
+    assert _is_loopback_host("0.0.0.0") is False
 
 
 def test_create_server_rejects_non_loopback_host_by_default():
     with pytest.raises(ValueError, match="loopback hosts"):
         create_dev_http_server(("0.0.0.0", 0), service=_service(), scenario_id=MILTON_SCENARIO_ID)
+
 
 def test_invalid_start_payload_returns_transport_error_over_http(http_base_url):
     status, body = _request(

--- a/tests/test_orchestration_http.py
+++ b/tests/test_orchestration_http.py
@@ -13,7 +13,7 @@ import pytest
 
 from war_room.models import CaseIntake
 from war_room.orchestration_api_contracts import StartRunRequest, start_run_request_to_payload
-from war_room.orchestration_http import create_dev_http_server
+from war_room.orchestration_http import MAX_REQUEST_BODY_BYTES, create_dev_http_server
 from war_room.orchestration_service import InMemoryOrchestrationService
 from war_room.scenarios import load_scenario
 
@@ -160,6 +160,27 @@ def test_invalid_json_returns_http_error_with_transport_style_envelope(http_base
     assert body["payload"]["error"]["code"] == "invalid_json"
     assert body["status_presentation"] is None
 
+
+
+
+def test_request_body_too_large_returns_clear_json_error(http_base_url):
+    oversized = b"{" + (b" " * MAX_REQUEST_BODY_BYTES) + b"}"
+    status, body = _request(
+        http_base_url,
+        "POST",
+        "/runs",
+        raw_body=oversized,
+    )
+
+    assert status == 400
+    assert body["ok"] is False
+    assert body["operation"] == "start_run"
+    assert body["payload"]["error"]["code"] == "request_too_large"
+
+
+def test_create_server_rejects_non_loopback_host_by_default():
+    with pytest.raises(ValueError, match="loopback hosts"):
+        create_dev_http_server(("0.0.0.0", 0), service=_service(), scenario_id=MILTON_SCENARIO_ID)
 
 def test_invalid_start_payload_returns_transport_error_over_http(http_base_url):
     status, body = _request(


### PR DESCRIPTION
### Motivation
- A security scan found the dev HTTP adapter trusted attacker-controlled `Content-Length` and allowed non-loopback binding, enabling memory/thread exhaustion and unauthenticated state changes if exposed beyond localhost.
- Apply minimal, dev-only guards so the adapter remains useful for local probes while reducing accidental or trivial abuse vectors.

### Description
- Add a 1 MiB request-body cap via `MAX_REQUEST_BODY_BYTES` and reject requests larger than this with a transport-style `request_too_large` error before calling `rfile.read(...)`.
- Require an intentional opt-in for non-loopback binds by adding an `allow_non_loopback` parameter to `create_dev_http_server` and a CLI flag `--allow-non-loopback`, and normalize common loopback host forms in `_is_loopback_host`.
- Add targeted regression coverage for oversized `Content-Length`, non-loopback rejection, and loopback host policy behavior.
- Keep the change narrow to the dev adapter (`src/war_room/orchestration_http.py`) and do not introduce auth, rate-limiting, or production API behavior.

### Testing
- `git diff --check` -> passed.
- `python -m pytest tests/test_orchestration_http.py::test_request_body_too_large_returns_clear_json_error tests/test_orchestration_http.py::test_loopback_host_policy_accepts_common_loopback_forms -q` -> `2 passed in 9.50s`.
- `python -m pytest tests/test_orchestration_http.py tests/test_orchestration_transport.py tests/test_orchestration_service.py -q` -> `22 passed in 7.49s`.
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `473 passed in 29.06s`.
- GitHub Actions on `e13dccab5048c53bad7eb29a0b99e71982b90ec2` -> 16 check runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da4ce9f8c8320b3cf4e76c6ec15f4)