### PR TITLE
fix: enforce domain-boundary matching for official source scoring

### DIFF
--- a/src/war_room/source_scoring.py
+++ b/src/war_room/source_scoring.py
@@ -129,23 +129,31 @@ _SOURCE_CLASS_LABELS = {
 _PRIMARY_SOURCE_CLASSES = {"court_opinion", "statute_regulation"}
 
 
+def _host_matches_domain(hostname: str, domain: str) -> bool:
+    """Return True when hostname is exactly domain or a subdomain of domain."""
+    return hostname == domain or hostname.endswith("." + domain)
+
+
 def _classify_domain(hostname: str) -> str:
     """Classify a hostname into a scoring tier."""
     hostname = hostname.lower().removeprefix("www.")
 
     # Check paywalled first (takes priority)
     for domain in PAYWALLED_DOMAINS:
-        if hostname == domain or hostname.endswith("." + domain):
+        if _host_matches_domain(hostname, domain):
             return "paywalled"
 
     # Check official
     for domain in OFFICIAL_DOMAINS:
-        if hostname.endswith(domain):
+        if domain.startswith("."):
+            if hostname.endswith(domain):
+                return "official"
+        elif _host_matches_domain(hostname, domain):
             return "official"
 
     # Check professional
     for domain in PROFESSIONAL_DOMAINS:
-        if hostname == domain or hostname.endswith("." + domain):
+        if _host_matches_domain(hostname, domain):
             return "professional"
 
     return "unvetted"

--- a/tests/test_source_scoring.py
+++ b/tests/test_source_scoring.py
@@ -107,3 +107,13 @@ def test_commentary_title_classifies_as_commentary():
     )
     assert result["source_class"] == "commentary"
     assert result["is_primary_authority"] is False
+
+
+def test_sibling_domain_does_not_match_official_domain():
+    result = score_url("https://evilcourtlistener.com/opinion/12345/")
+    assert result["tier"] == "unvetted"
+
+
+def test_subdomain_still_matches_official_domain():
+    result = score_url("https://api.courtlistener.com/opinion/12345/")
+    assert result["tier"] == "official"


### PR DESCRIPTION
### Motivation
- Loose suffix matching (`hostname.endswith(domain)`) allowed registrable domains like `courtlistener.com` to match attacker-controlled sibling hosts such as `evilcourtlistener.com`, which could be elevated to `official` and cause citation verification to mark spoofed hits as `verified`.
- Harden matching at the domain-label boundary to preserve integrity of source credibility signals without changing domain tier membership semantics for intentionally prefix-style entries like `.gov`.

### Description
- Add helper `_host_matches_domain(hostname, domain)` and use it for paywalled/professional checks so matches require exact host or dot-delimited subdomain when appropriate.
- Change official-domain logic to keep existing suffix behavior for entries that start with a leading dot (e.g. `.gov`) but require label-bound matches for bare registrable domains such as `courtlistener.com`.
- Add two regression tests to `tests/test_source_scoring.py` that assert a sibling domain (`evilcourtlistener.com`) is not `official` and that a valid subdomain (`api.courtlistener.com`) remains `official`.
- Files changed: `src/war_room/source_scoring.py`, `tests/test_source_scoring.py`.

### Testing
- Ran `git diff --check` with no issues reported.
- Ran `PYTHONPATH=src pytest -q tests/test_source_scoring.py` and the suite passed (`19 passed`).
- Attempting the broader collection (`pytest` including `tests/test_citation_verify.py`) failed during import collection due to a missing dependency (`ModuleNotFoundError: No module named 'pydantic'`) in this environment, so full verify should be run in a bootstrapped environment with `pip install -r requirements.txt && pip install -e . --no-deps --no-build-isolation` and then `python -m war_room --verify`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaaa83c8320bc71c273995c69e3)