### PR TITLE
fix: sanitize untrusted text in evidence board plain-text renderer

### DIFF
--- a/src/war_room/evidence_board.py
+++ b/src/war_room/evidence_board.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html
+import re
 from typing import Any, Mapping
 
 from war_room.models import (
@@ -20,6 +21,23 @@ from war_room.models import (
     adapt_run_audit_snapshot,
     run_audit_snapshot_from_parts,
 )
+
+
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _sanitize_text(value: str | None, *, max_len: int | None = None) -> str:
+    """Normalize untrusted text for plain-text evidence board rendering."""
+
+    text = value or ""
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    text = text.replace("\r", " ").replace("\n", " ")
+    text = "".join(ch if ch.isprintable() else " " for ch in text)
+    text = " ".join(text.split())
+    if max_len is not None:
+        return text[:max_len]
+    return text
 
 
 def build_evidence_board(
@@ -184,7 +202,7 @@ def format_evidence_board(board: Mapping[str, Any] | EvidenceBoardReadModel) -> 
         lines.append("  Clustering unavailable. Falling back to item view.")
         for item in board.ungrouped_items:
             lines.append(
-                f"  - {item.evidence_id} | {item.module} | {item.source_tier} | {item.title[:60]}"
+                f"  - {_sanitize_text(item.evidence_id)} | {_sanitize_text(item.module)} | {_sanitize_text(item.source_tier)} | {_sanitize_text(item.title, max_len=60)}"
             )
         lines.append("=" * 60)
         return "\n".join(lines)
@@ -192,24 +210,33 @@ def format_evidence_board(board: Mapping[str, Any] | EvidenceBoardReadModel) -> 
     for card in board.cluster_cards:
         state = "review_required" if card.review_required else "ready"
         lines.append(
-            f"  [{state}] {card.cluster_id} | {card.cluster_type} | {card.member_count} items"
+            f"  [{state}] {_sanitize_text(card.cluster_id)} | {_sanitize_text(card.cluster_type)} | {card.member_count} items"
         )
-        lines.append(f"    Label: {card.label}")
-        lines.append(f"    Modules: {', '.join(card.modules) or 'none'}")
-        lines.append(f"    Source tiers: {card.source_tier_summary or 'unknown'}")
+        lines.append(f"    Label: {_sanitize_text(card.label)}")
+        lines.append(
+            f"    Modules: {', '.join(_sanitize_text(module) for module in card.modules) or 'none'}"
+        )
+        lines.append(f"    Source tiers: {_sanitize_text(card.source_tier_summary or 'unknown')}")
         if card.issue_labels:
-            lines.append(f"    Issues: {', '.join(card.issue_labels)}")
+            lines.append(
+                f"    Issues: {', '.join(_sanitize_text(label) for label in card.issue_labels)}"
+            )
         if card.claim_ids:
-            lines.append(f"    Claims: {', '.join(card.claim_ids)}")
+            lines.append(
+                f"    Claims: {', '.join(_sanitize_text(claim_id) for claim_id in card.claim_ids)}"
+            )
         if card.review_event_ids:
-            lines.append(f"    Review events: {', '.join(card.review_event_ids)}")
+            lines.append(
+                "    Review events: "
+                f"{', '.join(_sanitize_text(event_id) for event_id in card.review_event_ids)}"
+            )
         if card.provenance_urls:
             lines.append(f"    Provenance URLs: {len(card.provenance_urls)}")
         lines.append("    Evidence:")
         for item in card.evidence_previews:
-            title = item.title[:56]
+            title = _sanitize_text(item.title, max_len=56)
             lines.append(
-                f"      - {item.evidence_id} | {item.module} | {item.source_tier} | {title}"
+                f"      - {_sanitize_text(item.evidence_id)} | {_sanitize_text(item.module)} | {_sanitize_text(item.source_tier)} | {title}"
             )
         lines.append("")
 

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -255,6 +255,25 @@ def test_render_evidence_board_html_surfaces_review_cues_and_escapes_content():
     assert "javascript:alert" not in rendered
 
 
+def test_format_evidence_board_sanitizes_control_chars_and_newlines():
+    board = build_evidence_board_from_parts(*_sample_parts())
+    payload = evidence_board_to_payload(board)
+    payload["cluster_cards"][0]["label"] = "NOAA\n[ready] forged | url | 99 items"
+    payload["cluster_cards"][0]["issue_labels"] = [
+        "coverage\r\nClaims: forged_claim",
+    ]
+    payload["cluster_cards"][0]["evidence_previews"][0]["title"] = (
+        "Report\x1b[31mRED\x1b[0m\n- fake-ev | weather | primary | forged"
+    )
+
+    rendered = format_evidence_board(payload)
+
+    assert "forged | url | 99 items" in rendered
+    assert "\n[ready] forged | url | 99 items" not in rendered
+    assert "Claims: forged_claim" in rendered
+    assert "\x1b" not in rendered
+
+
 def test_build_evidence_board_keeps_verified_citation_cluster_ready_when_only_peer_citations_are_uncertain():
     intake, weather, carrier, caselaw, _, query_plan = _sample_parts()
     weather.pop("warnings")


### PR DESCRIPTION
### Motivation
- Prevent operator-facing output spoofing by normalizing and stripping control/ANSI characters from untrusted evidence metadata that is interpolated into the plain-text evidence board renderer.
- Keep the fix minimal and scoped to the text-rendering sink so the evidence read-model and HTML renderer behavior are unchanged.

### Description
- Added `_sanitize_text()` to `src/war_room/evidence_board.py` which strips ANSI escape sequences, replaces CR/LF with spaces, removes non-printable characters, collapses whitespace, and supports optional truncation.
- Applied `_sanitize_text()` across the plain-text formatter `format_evidence_board()` for fallback item rows, cluster header rows, `cluster_id`, `cluster_type`, `label`, `modules`, `source_tier_summary`, `issue_labels`, `claim_ids`, `review_event_ids`, and evidence preview fields.
- Added a focused regression test `test_format_evidence_board_sanitizes_control_chars_and_newlines` in `tests/test_evidence_board.py` that injects newlines, carriage returns, and ANSI escapes into label/issue/title fields and asserts the rendered output is normalized and free of raw escape characters.
- Did not change HTML rendering or read-model construction to preserve existing contracts and keep the diff small.

### Testing
- Ran `git diff --check` locally and it passed.
- Attempted to run the targeted tests with `PYTHONPATH=src pytest -q tests/test_evidence_board.py` but test collection failed due to a missing environment dependency: `ModuleNotFoundError: No module named 'pydantic'` in this container, so automated test execution could not be completed here.
- Recommend running the supported verification path in a fully bootstrapped environment with `pip install -r requirements.txt` and `pip install -e . --no-deps --no-build-isolation` followed by `python -m war_room --verify` or `pytest -q` to validate the added regression test and full suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaa8ef48320a6db714cc73280b3)