### PR TITLE
fix: downgrade unverified Texas hail fixture sources

### DIFF
--- a/cache_samples/carrier_allstate_texas_lloyds_texas_hailstorm_tx_8cfd0fc4ea6f3646.json
+++ b/cache_samples/carrier_allstate_texas_lloyds_texas_hailstorm_tx_8cfd0fc4ea6f3646.json
@@ -18,8 +18,8 @@
       "doc_type": "DOI/Regulatory Complaint",
       "title": "Texas Department of Insurance market conduct action involving Allstate Texas Lloyds",
       "url": "https://www.tdi.texas.gov/orders/documents/allstate-market-conduct-order.pdf",
-      "badge": "official",
-      "why_it_matters": "Regulatory findings may support questions about claims handling discipline."
+      "badge": "unvetted",
+      "why_it_matters": "Illustrative claim-handling context from an unverified demo fixture source; independently verify before reliance."
     },
     {
       "doc_type": "Denial Pattern Analysis",
@@ -48,14 +48,14 @@
     {
       "title": "Texas Department of Insurance market conduct action involving Allstate Texas Lloyds",
       "url": "https://www.tdi.texas.gov/orders/documents/allstate-market-conduct-order.pdf",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "North Texas hail claim dispute involving Allstate Texas Lloyds",
       "url": "https://www.insurancejournal.com/news/southcentral/2024/06/10/777777.htm",
       "badge": "unvetted",
-      "reason": "Unvetted source"
+      "reason": "Unverified demo fixture source"
     }
   ]
 }

--- a/cache_samples/tx_hail_allstate_tarrant/carrier.json
+++ b/cache_samples/tx_hail_allstate_tarrant/carrier.json
@@ -18,8 +18,8 @@
       "doc_type": "DOI/Regulatory Complaint",
       "title": "Texas Department of Insurance market conduct action involving Allstate Texas Lloyds",
       "url": "https://www.tdi.texas.gov/orders/documents/allstate-market-conduct-order.pdf",
-      "badge": "official",
-      "why_it_matters": "Regulatory findings may support questions about claims handling discipline."
+      "badge": "unvetted",
+      "why_it_matters": "Illustrative claim-handling context from an unverified demo fixture source; independently verify before reliance."
     },
     {
       "doc_type": "Denial Pattern Analysis",
@@ -48,14 +48,14 @@
     {
       "title": "Texas Department of Insurance market conduct action involving Allstate Texas Lloyds",
       "url": "https://www.tdi.texas.gov/orders/documents/allstate-market-conduct-order.pdf",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "North Texas hail claim dispute involving Allstate Texas Lloyds",
       "url": "https://www.insurancejournal.com/news/southcentral/2024/06/10/777777.htm",
       "badge": "unvetted",
-      "reason": "Unvetted source"
+      "reason": "Unverified demo fixture source"
     }
   ]
 }

--- a/cache_samples/tx_hail_allstate_tarrant/weather.json
+++ b/cache_samples/tx_hail_allstate_tarrant/weather.json
@@ -14,20 +14,20 @@
     {
       "title": "Storm Events Database - Tarrant County hail event",
       "url": "https://www.ncei.noaa.gov/stormevents/eventdetails.jsp?id=1111111",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "NWS Fort Worth/Dallas severe weather summary",
       "url": "https://www.weather.gov/fwd/may2023hailsummary",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "Texas Division of Emergency Management incident update",
       "url": "https://tdem.texas.gov/disasters/2023/may-hail-event",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     }
   ]
 }

--- a/cache_samples/weather_texas_hailstorm_tarrant_tx_b465ee53deffdd7d.json
+++ b/cache_samples/weather_texas_hailstorm_tarrant_tx_b465ee53deffdd7d.json
@@ -14,20 +14,20 @@
     {
       "title": "Storm Events Database - Tarrant County hail event",
       "url": "https://www.ncei.noaa.gov/stormevents/eventdetails.jsp?id=1111111",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "NWS Fort Worth/Dallas severe weather summary",
       "url": "https://www.weather.gov/fwd/may2023hailsummary",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     },
     {
       "title": "Texas Division of Emergency Management incident update",
       "url": "https://tdem.texas.gov/disasters/2023/may-hail-event",
-      "badge": "official",
-      "reason": "Official source"
+      "badge": "unvetted",
+      "reason": "Unverified demo fixture source"
     }
   ]
 }

--- a/tests/golden/offline_fixture_snapshots.json
+++ b/tests/golden/offline_fixture_snapshots.json
@@ -256,9 +256,9 @@
       "review_required_issue_count": 4,
       "review_required_memo_section_count": 1,
       "source_badge_counts": {
-        "official": 6,
+        "official": 1,
         "professional": 6,
-        "unvetted": 4
+        "unvetted": 9
       },
       "state": "TX",
       "weather_source_count": 3,


### PR DESCRIPTION
### Motivation
- Prevent committed demo fixtures from being treated as authoritative "official" evidence by the cache-first runtime, by marking suspicious/placeholder Texas hail sources as unvetted and clearly labeling them as unverified demo fixtures.

### Description
- Changed source `badge` and `reason` metadata (and one `why_it_matters` text) from `official`/`Official source` to `unvetted`/`Unverified demo fixture source` in four committed fixture files: `cache_samples/weather_texas_hailstorm_tarrant_tx_b465ee53deffdd7d.json`, `cache_samples/carrier_allstate_texas_lloyds_texas_hailstorm_tx_8cfd0fc4ea6f3646.json`, `cache_samples/tx_hail_allstate_tarrant/weather.json`, and `cache_samples/tx_hail_allstate_tarrant/carrier.json`.

### Testing
- Ran `git diff --check`, which passed; attempted `python -m war_room --verify` but it failed in this container with `No module named war_room`; attempted `pip install -e . --no-deps --no-build-isolation` but the build backend was unavailable (`Cannot import 'setuptools.build_meta'`); attempted `PYTHONPATH=src pytest -q tests/test_offline_demo_pack.py tests/test_intake_validation.py` but collection failed due to a missing dependency (`pydantic`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaab06808320bab7004ee51c4053)