### PR TITLE
ci: harden push-triggered workflows for codex branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - codex/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Fresh Env Tests
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -67,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -130,6 +137,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -177,6 +186,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -215,6 +226,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -271,6 +284,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/exa-compat-matrix.yml
+++ b/.github/workflows/exa-compat-matrix.yml
@@ -10,6 +10,9 @@ on:
       - codex/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   exa-matrix:
     name: exa-py (${{ matrix.exa_spec }})
@@ -25,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Motivation
- Remediate a CI configuration risk where push-triggered workflows (including `codex/**`) ran branch-controlled install/test steps without explicit token minimization, allowing branch-controlled code to access persisted checkout credentials.

### Description
- Add top-level `permissions: contents: read` and set `persist-credentials: false` on all `actions/checkout@v4` uses in `.github/workflows/ci.yml` and `.github/workflows/exa-compat-matrix.yml` to reduce `GITHUB_TOKEN` scope and prevent checkout credential persistence while preserving existing triggers and job behavior.

### Testing
- Ran `git diff --check` which passed; attempted supported verify with `python -m war_room --verify` but it failed in this container because the editable package/install is not present (`No module named war_room`); attempted `PYTHONPATH=src python -m pytest -q tests/test_offline_demo_pack.py` which failed during collection due to missing runtime dependency `pydantic` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaabe9cc83209ee7b20ba52a4c89)