### PR TITLE
fix: honor process environment overrides in shared settings loader

### DIFF
--- a/src/war_room/settings.py
+++ b/src/war_room/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
+import os
 from pathlib import Path
 from typing import Any
 
@@ -114,13 +115,14 @@ def load_settings(*, repo_root: Path, env_file: Path | None = None) -> WarRoomSe
 
 
 def _read_env_values(env_file: Path) -> dict[str, str]:
-    if not env_file.exists():
-        return {}
-
     values: dict[str, str] = {}
-    for key, value in dotenv_values(env_file).items():
-        if value is not None:
-            values[key] = value
+
+    if env_file.exists():
+        for key, value in dotenv_values(env_file).items():
+            if value is not None:
+                values[key] = value
+
+    values.update(os.environ)
     return values
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,3 +40,18 @@ def test_invalid_boolean_rejected(tmp_path: Path):
 
     with pytest.raises(ValueError):
         load_settings(repo_root=tmp_path, env_file=env_file)
+
+
+def test_process_environment_overrides_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    env_file = tmp_path / ".env"
+    env_file.write_text("WAR_ROOM_ENV=local\nALLOW_LIVE_RETRIEVAL=true\nEXA_API_KEY=file-key\n", encoding="utf-8")
+
+    monkeypatch.setenv("WAR_ROOM_ENV", "demo")
+    monkeypatch.setenv("ALLOW_LIVE_RETRIEVAL", "false")
+    monkeypatch.setenv("EXA_API_KEY", "")
+
+    settings = load_settings(repo_root=tmp_path, env_file=env_file)
+
+    assert settings.app_env == RuntimeEnvironment.DEMO
+    assert settings.live_retrieval_enabled is False
+    assert settings.exa_api_key_value == ""


### PR DESCRIPTION
### Motivation
- The settings loader documented that process environment overrides should take precedence over `.env`, but `_read_env_values()` only read the dotenv file, causing operator-level kill-switches like `ALLOW_LIVE_RETRIEVAL=false` or `WAR_ROOM_ENV=demo` to be silently ignored.
- This is security-relevant because live retrieval and API-key presence drive third-party Exa calls that may leak sensitive case material when process-level overrides are intended to disable them.

### Description
- Updated `src/war_room/settings.py` to merge `os.environ` on top of parsed `.env` values so process environment variables override file defaults by changing `_read_env_values()` and adding `import os`.
- Preserved `.env` as the baseline while ensuring runtime controls (`WAR_ROOM_ENV`, `ALLOW_LIVE_RETRIEVAL`, `EXA_API_KEY`, path overrides, etc.) can be overridden at process level by calling `values.update(os.environ)` after reading the file.
- Added a focused regression test `tests/test_settings.py::test_process_environment_overrides_env_file` that verifies `WAR_ROOM_ENV`, `ALLOW_LIVE_RETRIEVAL`, and `EXA_API_KEY` from the process environment take precedence over `.env`.

### Testing
- Ran `git diff --check` to verify no whitespace/patch issues and committed the change successfully.
- Attempted to run the targeted tests with `pytest -q tests/test_settings.py` and `PYTHONPATH=src pytest -q tests/test_settings.py` but collection failed in this container due to the environment missing `python-dotenv` (dependency not installed here), so the automated test was not executed to completion in this runner.
- Recommended verification steps for maintainers: bootstrap the repo and run `pip install -r requirements.txt && pip install -e . --no-deps --no-build-isolation` then run `python -m war_room --verify` or `pytest -q` to validate end-to-end behavior with the new regression test included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaaf29c8320aefed7fd78b2f67d)