### PR TITLE
fix: prevent lookalike official-domain promotion in source scoring

### DIFF
--- a/src/war_room/source_scoring.py
+++ b/src/war_room/source_scoring.py
@@ -140,7 +140,11 @@ def _classify_domain(hostname: str) -> str:
 
     # Check official
     for domain in OFFICIAL_DOMAINS:
-        if hostname.endswith(domain):
+        if domain.startswith("."):
+            if hostname.endswith(domain):
+                return "official"
+            continue
+        if hostname == domain or hostname.endswith("." + domain):
             return "official"
 
     # Check professional

--- a/tests/test_source_scoring.py
+++ b/tests/test_source_scoring.py
@@ -107,3 +107,18 @@ def test_commentary_title_classifies_as_commentary():
     )
     assert result["source_class"] == "commentary"
     assert result["is_primary_authority"] is False
+
+
+def test_lookalike_floir_is_not_official():
+    result = score_url("https://evilfloir.com/fake-order")
+    assert result["tier"] == "unvetted"
+
+
+def test_lookalike_courtlistener_is_not_official():
+    result = score_url("https://evilcourtlistener.com/opinion/123")
+    assert result["tier"] == "unvetted"
+
+
+def test_subdomain_of_official_domain_is_still_official():
+    result = score_url("https://api.floir.com/orders/123")
+    assert result["tier"] == "official"


### PR DESCRIPTION
### Motivation
- A hostname-suffix check classified attacker-controlled lookalike hosts (for example `evilfloir.com`) as `official`, which combined with recent ranking changes could promote spoofed results into memo/review surfaces.

### Description
- Harden `_classify_domain` to treat OFFICIAL_DOMAINS entries that start with `.` as suffix-classes (e.g. `.gov`) while requiring explicit domains to match only by exact host or true subdomain (`hostname == domain or hostname.endswith('.' + domain)`).
- Added focused regression tests that assert `https://evilfloir.com/...` and `https://evilcourtlistener.com/...` are classified as `unvetted` and that `https://api.floir.com/...` remains `official`.
- No other ranking logic or domain lists were changed, and paywalled/professional matching behavior is preserved.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_source_scoring.py` and all tests passed (`20 passed`).
- Ran `git diff --check` which reported no whitespace or diff issues.
- Attempted the supported repo verify `python -m war_room --verify` but it was blocked in this environment because `pip install -e .` failed due to a missing `setuptools.build_meta` backend; recommend running the full verify flow in a fully provisioned environment using `pip install -r requirements.txt` and `pip install -e . --no-deps --no-build-isolation` before `python -m war_room --verify`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaac0fa48320b661ca05af688a7d)