### PR TITLE
fix: sanitize evidence appendix markdown fields

### DIFF
--- a/src/war_room/export_md.py
+++ b/src/war_room/export_md.py
@@ -10,6 +10,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import urlparse
 
 from war_room.models import (
     CaseIntake,
@@ -416,7 +417,9 @@ def _append_evidence_index(lines: list[str], evidence_items: list[Any]) -> None:
         url = item.url or ""
         lines.append(
             f"| {item.evidence_id} | {item.module} | {item.evidence_type} | "
-            f"{_clean_inline_text(title, limit=50, table_safe=True)} | {item.badge} | {url} |"
+            f"{_clean_markdown_field(title, limit=50, table_safe=True)} | "
+            f"{_clean_markdown_field(item.badge, limit=24, table_safe=True)} | "
+            f"{_safe_markdown_url(url)} |"
         )
     lines.append("")
 
@@ -426,7 +429,8 @@ def _append_review_log(lines: list[str], review_events: list[Any]) -> None:
     for event in review_events:
         cluster_ids = ", ".join(event.related_cluster_ids) if event.related_cluster_ids else "none"
         lines.append(
-            f"- **{_clean_inline_text(event.label, limit=80)}:** {_clean_inline_text(event.detail, limit=180)} "
+            f"- **{_clean_markdown_field(event.label, limit=80)}:** "
+            f"{_clean_markdown_field(event.detail, limit=180)} "
             f"| Evidence clusters: {cluster_ids}"
         )
     lines.append("")
@@ -593,6 +597,28 @@ def _clean_inline_text(
     if limit is not None and len(text) > limit:
         return text[: max(0, limit - 3)].rstrip() + "..."
     return text
+
+
+def _clean_markdown_field(
+    value: Any,
+    *,
+    limit: int | None = None,
+    table_safe: bool = False,
+) -> str:
+    """Clean untrusted text for markdown output and escape raw HTML."""
+    cleaned = _clean_inline_text(value, limit=limit, table_safe=table_safe)
+    return html.escape(cleaned, quote=False)
+
+
+def _safe_markdown_url(value: Any) -> str:
+    """Return only safe URL schemes for markdown output."""
+    url = _clean_inline_text(value, limit=300, table_safe=True)
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in {"http", "https"}:
+        return ""
+    return html.escape(url, quote=False)
 
 
 def _humanize_token(value: str) -> str:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -347,6 +347,23 @@ def test_render_includes_canonical_evidence_index_rows():
     assert "| citation-check-1 |" not in md
 
 
+def test_render_sanitizes_evidence_index_and_review_log_untrusted_fields():
+    intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
+    citecheck["checks"][0]["case_name"] = "Legit <img src=x onerror=alert(1)>"
+    citecheck["checks"][0]["badge"] = "verified|<script>alert(1)</script>"
+    citecheck["checks"][0]["source_url"] = "javascript:alert(1)"
+    weather["warnings"] = ["<img src=x onerror=alert('review')>"]
+    citecheck["summary"] = {"total": 1, "verified": 0, "uncertain": 1, "not_found": 0}
+    citecheck["checks"][0]["status"] = "uncertain"
+
+    md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
+
+    assert "<img" not in md
+    assert "<script>" not in md
+    assert "javascript:alert(1)" not in md
+    assert "verified/&lt;script&gt;alert(1)&lt;/script&gt;" in md
+
+
 def test_render_accepts_dict_intake_and_query_specs():
     intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
 


### PR DESCRIPTION
### Motivation

- Prevent Markdown/HTML injection from untrusted EvidenceItem fields and ReviewEvent details when rendering the memo appendices.  The Evidence Index and Review Log previously interpolated `title`, `badge`, `url`, `label`, and `detail` values directly into Markdown.  

### Description

- Added `_clean_markdown_field(...)` to escape HTML-sensitive characters for evidence and review text before interpolation, and used it for Evidence Index `title`/`badge` and Review Log `label`/`detail` fields in `src/war_room/export_md.py`.
- Added `_safe_markdown_url(...)` which allowlists URL schemes (`http`/`https`) and drops unsafe schemes like `javascript:` before emitting evidence URLs in the Evidence Index in `src/war_room/export_md.py`.
- Added a regression test `test_render_sanitizes_evidence_index_and_review_log_untrusted_fields` in `tests/test_export.py` which injects malicious HTML/script/unsafe-URL values and asserts they are neutralized in the rendered memo.

### Testing

- Ran `git diff --check` locally and it returned clean (no whitespace errors).
- Attempted to run targeted pytest for the new test and related export tests via `PYTHONPATH=src pytest -q tests/test_export.py::test_render_sanitizes_evidence_index_and_review_log_untrusted_fields tests/test_export.py::test_render_includes_canonical_evidence_index_rows`, but test collection failed due to missing pinned dependencies (`pydantic` / `python-dotenv`) in this environment; pytest raised `ModuleNotFoundError: No module named 'pydantic'`.
- Attempted `pip install -r requirements.txt` to satisfy deps but the install failed due to network/index access issues (could not fetch `python-dotenv==1.0.1`).

Please re-run the targeted pytest and the repository verify path in an environment with network access to the package index or after installing pinned dependencies: `pytest -q tests/test_export.py::test_render_sanitizes_evidence_index_and_review_log_untrusted_fields` and `python -m war_room --verify`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaaa1588320bd43ec7737f5a9e2)