### PR TITLE
fix(ci): restrict CI token permissions and disable persisted checkout credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
       - codex/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Fresh Env Tests
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -67,6 +72,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -130,6 +137,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -177,6 +186,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -215,6 +226,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -271,6 +284,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
### Motivation
- Prevent untrusted pull-request code from inheriting write-capable Actions credentials by applying least-privilege permissions and disabling persisted checkout credentials in the workflow.

### Description
- Add a top-level `permissions: contents: read` block to `.github/workflows/ci.yml` and set `persist-credentials: false` on every `actions/checkout@v4` step to remove token-backed git credentials from later steps while preserving existing jobs and test behavior.

### Testing
- Ran repository validation commands including `git status --short --branch`, `git diff --check`, and inspected `git diff` / the updated workflow file to confirm the `permissions` block and `persist-credentials: false` were added; `git diff --check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaab6c9883209c32d11ca8c181f0)