### PR TITLE
Fix secret-scanner bypass for loose `not set` status matching

### DIFF
--- a/src/war_room/security_hygiene.py
+++ b/src/war_room/security_hygiene.py
@@ -542,7 +542,7 @@ def _looks_like_python_type_annotation(line: str, match: re.Match[str]) -> bool:
 
 def _looks_like_not_set_status(line: str, match: re.Match[str]) -> bool:
     suffix = line[match.start("value") :].strip().strip("'\"")
-    return bool(re.match(r"not\s+set\b", suffix, flags=re.IGNORECASE))
+    return bool(re.fullmatch(r"not\s+set", suffix, flags=re.IGNORECASE))
 
 
 def _normalize_policy_text(text: str) -> str:

--- a/tests/test_security_hygiene.py
+++ b/tests/test_security_hygiene.py
@@ -74,6 +74,25 @@ def test_security_hygiene_allows_not_set_status_text(tmp_path: Path):
     assert report.passed
 
 
+
+
+def test_security_hygiene_flags_not_set_prefix_with_trailing_secret(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    secret_name = "EXA_API" + "_KEY"
+    _write(
+        tmp_path / "notebooks" / "demo.ipynb",
+        f"  {secret_name}: not set exa_live_REAL_SECRET_1234567890\n",
+    )
+    tracked_files.append("notebooks/demo.ipynb")
+
+    report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert not report.passed
+    findings = _check(report, "obvious-secret-patterns").findings
+    assert len(findings) == 1
+    assert findings[0].path == "notebooks/demo.ipynb"
+    assert findings[0].line == 1
+
 def test_security_hygiene_flags_env_template_drift(tmp_path: Path):
     tracked_files = _write_compliant_repo(tmp_path)
     exa_key = "EXA_API" + "_KEY"


### PR DESCRIPTION
### Motivation
- Close a security-hygiene bypass where lines whose value text merely started with `not set` (e.g. `EXA_API_KEY: not set exa_live_REAL_SECRET`) were treated as harmless and skipped, allowing trailing secret material to evade detection.

### Description
- Tighten `_looks_like_not_set_status` in `src/war_room/security_hygiene.py` to require the captured status value to be exactly `not set` (case-insensitive) by switching from `re.match(...)` to `re.fullmatch(...)` for the suffix check, and add a focused regression test `test_security_hygiene_flags_not_set_prefix_with_trailing_secret` in `tests/test_security_hygiene.py` to assert that `EXA_API_KEY: not set exa_live_REAL_SECRET_...` is now flagged.

### Testing
- Ran `git diff --check` which passed; attempted `python -m pytest tests/test_security_hygiene.py -q` and `PYTHONPATH=src python -m pytest tests/test_security_hygiene.py -q` but test collection/execution was blocked in this environment due to missing editable install and the `python-dotenv` dependency, and `pip install -r requirements.txt` failed here because network/package-index access is restricted; recommend running the normal verification path `pip install -e . --no-deps --no-build-isolation` followed by `python -m war_room --verify` or `pytest -q` in CI/local dev to confirm the regression test and full suite pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da5de181c83209ef389effed55d57)