### PR TITLE
fix: block direct-url pyproject dependencies in dependency hygiene gate

### DIFF
--- a/src/war_room/dependency_hygiene.py
+++ b/src/war_room/dependency_hygiene.py
@@ -114,7 +114,7 @@ def run_dependency_hygiene(
     pyproject_entries, pyproject_findings = _read_pyproject_dependency_entries(resolved_root / PYPROJECT_PATH)
     checks = [
         _check_requirements_pinned(resolved_root, requirements_entries),
-        _check_unsupported_requirement_sources(requirements_entries),
+        _check_unsupported_requirement_sources(requirements_entries + pyproject_entries),
         _check_duplicate_dependencies(requirements_entries + pyproject_entries),
         _check_pyproject_dependency_drift(
             resolved_root,
@@ -251,7 +251,7 @@ def _check_unsupported_requirement_sources(
         check_id="unsupported-requirement-sources",
         name="Unsupported Requirement Sources",
         findings=findings,
-        passed_summary="requirements.txt has no editable, local path, direct URL, git, include, or installer-option entries",
+        passed_summary="dependency manifests have no editable, local path, direct URL, git, include, or installer-option entries",
     )
 
 

--- a/tests/test_dependency_hygiene.py
+++ b/tests/test_dependency_hygiene.py
@@ -93,6 +93,29 @@ def test_dependency_hygiene_flags_duplicate_entries_and_pyproject_drift(tmp_path
     assert any("dependency is present in pyproject.toml but not requirements.txt: pydantic" in message for message in drift_messages)
 
 
+def test_dependency_hygiene_flags_direct_url_dependency_in_pyproject(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    _write(
+        tmp_path / "pyproject.toml",
+        _pyproject_dependencies(
+            [
+                *DEPENDENCIES,
+                "evil @ git+https://example.invalid/evil.git",
+            ]
+        ),
+    )
+
+    report = run_dependency_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert not report.passed
+    source_findings = _check(report, "unsupported-requirement-sources").findings
+    assert any(
+        finding.path == "pyproject.toml"
+        and finding.message == "direct URL or git requirements are not supported in committed dependency manifests"
+        for finding in source_findings
+    )
+
+
 def test_dependency_hygiene_flags_unsupported_dependency_file_and_doc_drift(tmp_path: Path):
     tracked_files = _write_compliant_repo(tmp_path)
     _write(tmp_path / "requirements-dev.txt", "pytest==8.3.4\n")


### PR DESCRIPTION
### Motivation
- A supply-chain bypass allowed PEP 508 direct references (e.g. `name @ git+https://...`) declared in `[project].dependencies` of `pyproject.toml` to evade the unsupported-source check that only inspected `requirements.txt` entries.

### Description
- Include parsed `pyproject.toml` entries when running the unsupported-source check by calling `_check_unsupported_requirement_sources(requirements_entries + pyproject_entries)` in `run_dependency_hygiene`.
- Update the unsupported-source check success summary to refer to "dependency manifests" instead of only `requirements.txt`.
- Add a regression test `test_dependency_hygiene_flags_direct_url_dependency_in_pyproject` to assert that a `pyproject.toml` direct-URL dependency triggers `unsupported-requirement-sources`.

### Testing
- Running the targeted tests with the package search path set (`PYTHONPATH=src python -m pytest -q tests/test_dependency_hygiene.py`) passed (`8 passed, 1 warning`).
- Running plain `python -m pytest -q tests/test_dependency_hygiene.py` without editable install/PYTHONPATH raised an import error in this environment, which is expected unless the package is installed or `PYTHONPATH` is set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da5deafb883209788b568c06c3f2b)