### PR TITLE
fix(ci): harden offline e2e artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,13 @@ jobs:
   offline-e2e:
     name: Offline E2E
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -227,6 +231,14 @@ jobs:
           pip install "setuptools>=69"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
+
+
+      - name: Prepare Offline E2E Artifact Directory
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf runs/offline_e2e
+          mkdir -p runs/offline_e2e
 
       - name: Offline E2E Gate - demo workflow artifacts
         shell: bash
@@ -259,7 +271,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: offline-e2e-demo-${{ github.run_id }}
-          path: runs/offline_e2e/
+          path: |
+            runs/offline_e2e/result.json
+            runs/offline_e2e/result.md
           if-no-files-found: error
 
   release-scorecard:


### PR DESCRIPTION
### Motivation
- Prevent CI artifact uploads from including attacker-controlled files or symlinks under the gitignored `runs/offline_e2e/` path which could leak runner-local secrets or checkout credentials.

### Description
- Add least-privilege workflow permissions (`contents: read`) and set `persist-credentials: false` on `actions/checkout@v4` for the `offline-e2e` job. 
- Add a pre-run cleanup step that removes and recreates `runs/offline_e2e` to eliminate any pre-existing PR-added files or symlinks. 
- Narrow the artifact upload path to only the expected generated files (`runs/offline_e2e/result.json` and `runs/offline_e2e/result.md`) instead of the whole directory.

### Testing
- Ran `git diff --check` which returned clean results. 
- Attempted `python -m pytest -q tests/test_offline_e2e.py` which errored in this environment due to missing package bootstrap (`ModuleNotFoundError: No module named 'war_room'`). 
- Attempted `PYTHONPATH=src python -m pytest -q tests/test_offline_e2e.py` which errored due to a missing dependency (`ModuleNotFoundError: No module named 'dotenv'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da5def9bc832096bf2b2bdc7276cf)