### PR TITLE
fix: narrow type-annotation skip in security hygiene secret scanner

### DIFF
--- a/src/war_room/security_hygiene.py
+++ b/src/war_room/security_hygiene.py
@@ -546,7 +546,10 @@ def _looks_like_python_type_annotation(path: str, line: str, match: re.Match[str
 
 def _looks_like_not_set_status(line: str, match: re.Match[str]) -> bool:
     suffix = line[match.start("value") :].strip().strip("'\"")
-    return bool(re.match(r"not\s+set\b", suffix, flags=re.IGNORECASE))
+    if "`" in line[: match.start("name")] and "`" in suffix:
+        suffix = suffix.split("`", 1)[0].strip().strip("'\"")
+    suffix = re.sub(r"(?:\\[rn])+$", "", suffix).strip()
+    return bool(re.fullmatch(r"not\s+set", suffix, flags=re.IGNORECASE))
 
 
 def _normalize_policy_text(text: str) -> str:

--- a/src/war_room/security_hygiene.py
+++ b/src/war_room/security_hygiene.py
@@ -263,7 +263,7 @@ def _check_secret_patterns(tracked: Sequence[_TrackedFile]) -> SecurityHygieneCh
             if _line_has_allowlist_marker(line):
                 continue
             for match in SECRET_ASSIGNMENT_PATTERN.finditer(line):
-                if _looks_like_python_type_annotation(line, match):
+                if _looks_like_python_type_annotation(tracked_file.path, line, match):
                     continue
                 if _looks_like_not_set_status(line, match):
                     continue
@@ -536,8 +536,12 @@ def _line_has_allowlist_marker(line: str) -> bool:
     return any(marker in lowered for marker in ALLOWLIST_MARKERS)
 
 
-def _looks_like_python_type_annotation(line: str, match: re.Match[str]) -> bool:
-    return match.group("sep") == ":" and "=" in line[match.end() :]
+def _looks_like_python_type_annotation(path: str, line: str, match: re.Match[str]) -> bool:
+    if match.group("sep") != ":":
+        return False
+    if Path(path).suffix != ".py":
+        return False
+    return bool(re.match(r"\s*[A-Za-z_][A-Za-z0-9_\[\],| .]*\s*=", line[match.start("value") :]))
 
 
 def _looks_like_not_set_status(line: str, match: re.Match[str]) -> bool:

--- a/tests/test_security_hygiene.py
+++ b/tests/test_security_hygiene.py
@@ -74,6 +74,38 @@ def test_security_hygiene_allows_not_set_status_text(tmp_path: Path):
     assert report.passed
 
 
+def test_security_hygiene_flags_not_set_prefix_with_trailing_secret(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    secret_name = "EXA_API" + "_KEY"
+    _write(
+        tmp_path / "notebooks" / "demo.ipynb",
+        f"  {secret_name}: not set exa_live_REAL_SECRET_1234567890\n",
+    )
+    tracked_files.append("notebooks/demo.ipynb")
+
+    report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert not report.passed
+    findings = _check(report, "obvious-secret-patterns").findings
+    assert len(findings) == 1
+    assert findings[0].path == "notebooks/demo.ipynb"
+    assert findings[0].line == 1
+
+
+def test_security_hygiene_allows_markdown_inline_not_set_status_text(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    secret_name = "EXA_API" + "_KEY"
+    _write(
+        tmp_path / "docs" / "notes.md",
+        f"Notebook output text `{secret_name}: not set` was treated as status text.\n",
+    )
+    tracked_files.append("docs/notes.md")
+
+    report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert report.passed
+
+
 def test_security_hygiene_flags_env_template_drift(tmp_path: Path):
     tracked_files = _write_compliant_repo(tmp_path)
     exa_key = "EXA_API" + "_KEY"
@@ -85,7 +117,6 @@ def test_security_hygiene_flags_env_template_drift(tmp_path: Path):
     messages = [finding.message for finding in _check(report, "env-example-expectations").findings]
     assert "missing expected setting WAR_ROOM_ENV" in messages
     assert "missing expected setting RUNS_DIR" in messages
-
 
 
 def test_security_hygiene_flags_colon_secret_with_later_equals_in_non_python_file(tmp_path: Path):
@@ -112,6 +143,7 @@ def test_security_hygiene_allows_python_type_annotation_with_placeholder_assignm
     report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
 
     assert report.passed
+
 
 def _write_compliant_repo(root: Path) -> list[str]:
     _write(root / ".env.example", "\n".join(f"{key}=" for key in EXPECTED_ENV_EXAMPLE_KEYS))

--- a/tests/test_security_hygiene.py
+++ b/tests/test_security_hygiene.py
@@ -87,6 +87,32 @@ def test_security_hygiene_flags_env_template_drift(tmp_path: Path):
     assert "missing expected setting RUNS_DIR" in messages
 
 
+
+def test_security_hygiene_flags_colon_secret_with_later_equals_in_non_python_file(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    secret_name = "EXA_API" + "_KEY"
+    secret_value = "live_secret_value_123456"
+    _write(tmp_path / "leak.yml", f"{secret_name}: {secret_value} other=value\n")
+    tracked_files.append("leak.yml")
+
+    report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert not report.passed
+    findings = _check(report, "obvious-secret-patterns").findings
+    assert len(findings) == 1
+    assert findings[0].path == "leak.yml"
+
+
+def test_security_hygiene_allows_python_type_annotation_with_placeholder_assignment(tmp_path: Path):
+    tracked_files = _write_compliant_repo(tmp_path)
+    secret_name = "EXA_API" + "_KEY"
+    _write(tmp_path / "src" / "settings.py", f"{secret_name}: str = 'not set'\n")
+    tracked_files.append("src/settings.py")
+
+    report = run_security_hygiene(tmp_path, tracked_files=tracked_files)
+
+    assert report.passed
+
 def _write_compliant_repo(root: Path) -> list[str]:
     _write(root / ".env.example", "\n".join(f"{key}=" for key in EXPECTED_ENV_EXAMPLE_KEYS))
     _write(root / ".gitignore", "\n".join([".env", "cache/", "output/", "runs/", ".exa_cache_live/"]))


### PR DESCRIPTION
### Motivation
- A security scanner could skip colon-style secret assignments when an `=` appeared later on the same line, causing real secrets in non-Python files (for example YAML) to be ignored by the CI security gate.
- PR #122 exposed a second bypass where values that merely started with `not set` could be treated as harmless status text, allowing trailing secret material such as `not set exa_live_REAL_SECRET_...` to evade detection.
- The intent is to preserve safe Python type-annotation and exact status-text suppression without weakening committed-secret detection.

### Description
- Pass the tracked file path into `_looks_like_python_type_annotation(...)` so type-annotation suppression is limited to `.py` files and colon separators.
- Tighten the Python annotation check so non-Python colon assignments with later `=` text are still flagged.
- Tighten `_looks_like_not_set_status(...)` so the status value must resolve exactly to `not set`, while preserving existing safe notebook escaped-newline and markdown inline-code status examples.
- Add regression tests for both bypasses and for the safe status/annotation cases that should remain allowed.

### Testing
- `git diff --check` -> passed.
- `git diff --check origin/main..HEAD` -> passed.
- `python -m pytest tests/test_security_hygiene.py -q` -> `10 passed in 2.24s`.
- `python -m war_room.security_hygiene --check` -> passed, `6/6` checks passed.
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `479 passed in 14.21s`; verify manifest written under `runs/verify/2026-05-20_codex-fix-security-hygiene-gate-for-secrets_20260520t182901z.json`.

### Consolidation note
- Absorbs PR #122 into this keeper branch. PR #122 should remain open until this PR merges, then it can be closed as redundant.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da5deeb608320884d27041f0bed68)