### PR TITLE
fix: escape decoded HTML before markdown rendering

### DIFF
--- a/src/war_room/caselaw_module.py
+++ b/src/war_room/caselaw_module.py
@@ -520,6 +520,7 @@ def _extract_case_info(result: dict) -> dict[str, Any]:
 
 def _clean_case_text(value: str) -> str:
     text = html.unescape(str(value or ""))
+    text = html.escape(text, quote=False)
     text = text.replace("\r", " ").replace("\n", " ")
     text = re.sub(r"\s+", " ", text).strip()
     return text

--- a/src/war_room/export_md.py
+++ b/src/war_room/export_md.py
@@ -585,6 +585,7 @@ def _clean_inline_text(
     table_safe: bool = False,
 ) -> str:
     text = html.unescape(str(value or ""))
+    text = html.escape(text, quote=False)
     text = text.replace("\r", " ").replace("\n", " ")
     text = re.sub(r"\[([^\]]+)\]", r"\1", text)
     text = re.sub(r"\s+", " ", text).strip()

--- a/tests/test_caselaw.py
+++ b/tests/test_caselaw.py
@@ -420,3 +420,19 @@ def test_build_caselaw_pack_without_client_returns_structured_fallback() -> None
     assert pack["sources"] == []
     assert "warnings" in pack
     assert any("No Exa client available" in warning for warning in pack["warnings"])
+
+
+def test_normalize_case_entry_escapes_entity_decoded_html() -> None:
+    entry = _normalize_case_entry(
+        {
+            "name": "&lt;img src=x onerror=alert(1)&gt;",
+            "citation": "&lt;b&gt;123 So. 3d 1&lt;/b&gt;",
+            "court": "Fla. App.",
+            "year": "2020",
+            "one_liner": "&lt;script&gt;boom()&lt;/script&gt;",
+            "url": "https://example.com/case",
+        }
+    )
+    assert entry["name"] == "&lt;img src=x onerror=alert(1)&gt;"
+    assert entry["citation"] == "&lt;b&gt;123 So. 3d 1&lt;/b&gt;"
+    assert "<script>" not in entry["one_liner"]

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -363,6 +363,19 @@ def test_render_accepts_dict_intake_and_query_specs():
     assert "Total queries: 1" in md
 
 
+def test_render_escapes_entity_decoded_html_payloads():
+    intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
+    payload = "&lt;img src=x onerror=alert(1)&gt;"
+    weather["sources"][0]["title"] = payload
+    carrier["document_pack"][0]["title"] = payload
+    caselaw["issues"][0]["cases"][0]["name"] = payload
+
+    md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
+
+    assert "&lt;img src=x onerror=alert(1)&gt;" in md
+    assert "<img src=x onerror=alert(1)>" not in md
+
+
 def test_write_markdown_creates_file():
     with tempfile.TemporaryDirectory() as tmpdir:
         path = write_markdown(tmpdir, "test_case", "# Test Memo\nContent here")


### PR DESCRIPTION
### Motivation
- A recent change decoded HTML entities for readability but returned the decoded text directly into Markdown sinks, creating a stored Markdown/HTML injection path when untrusted fixtures or retrieval results include encoded tags.  
- The goal is to prevent entity-decoded input from becoming raw HTML in generated memos while preserving readability and existing normalization behavior.

### Description
- Re-escape HTML-sensitive characters after entity decoding in `export_md._clean_inline_text` so values used in tables, links, bullets, and headings are safe for Markdown renderers. (file: `src/war_room/export_md.py`)  
- Re-escape HTML-sensitive characters after entity decoding in `caselaw_module._clean_case_text` so normalized case fields cannot inject raw HTML into downstream exports. (file: `src/war_room/caselaw_module.py`)  
- Added regression tests that verify memo rendering and case normalization keep entity-encoded payloads escaped and do not emit raw tags. (files: `tests/test_export.py`, `tests/test_caselaw.py`)

### Testing
- Added tests: `test_render_escapes_entity_decoded_html_payloads` in `tests/test_export.py` and `test_normalize_case_entry_escapes_entity_decoded_html` in `tests/test_caselaw.py`, which assert entity-encoded payloads remain escaped and raw HTML does not appear.  
- Attempted to run the targeted pytest subset with `python -m pytest tests/test_export.py tests/test_caselaw.py -q` and `PYTHONPATH=src python -m pytest tests/test_export.py tests/test_caselaw.py -q`, but test collection failed in this environment due to a missing runtime dependency (`pydantic`), so the tests could not be executed here.  
- Performed repository checks: `git diff --check` passed locally in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc7d8b0a48320a90e47a41c638c4e)