### PR TITLE
fix: escape markdown control chars in memo warning surfaces

### DIFF
--- a/src/war_room/export_md.py
+++ b/src/war_room/export_md.py
@@ -10,6 +10,7 @@ import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Mapping
+from urllib.parse import urlparse
 
 from war_room.models import (
     CaseIntake,
@@ -413,10 +414,11 @@ def _append_evidence_index(lines: list[str], evidence_items: list[Any]) -> None:
     lines.append("|----|--------|------|-------|-------|-----|")
     for item in evidence_items:
         title = item.title or item.summary or item.evidence_type
-        url = item.url or ""
+        url = _safe_markdown_url(item.url or "")
         lines.append(
             f"| {item.evidence_id} | {item.module} | {item.evidence_type} | "
-            f"{_clean_inline_text(title, limit=50, table_safe=True)} | {item.badge} | {url} |"
+            f"{_markdown_safe_text(title, limit=50, table_safe=True)} | "
+            f"{_markdown_safe_text(item.badge, limit=24, table_safe=True)} | {url} |"
         )
     lines.append("")
 
@@ -426,7 +428,8 @@ def _append_review_log(lines: list[str], review_events: list[Any]) -> None:
     for event in review_events:
         cluster_ids = ", ".join(event.related_cluster_ids) if event.related_cluster_ids else "none"
         lines.append(
-            f"- **{_clean_inline_text(event.label, limit=80)}:** {_clean_inline_text(event.detail, limit=180)} "
+            f"- **{_markdown_safe_text(event.label, limit=80)}:** "
+            f"{_markdown_safe_text(event.detail, limit=180)} "
             f"| Evidence clusters: {cluster_ids}"
         )
     lines.append("")
@@ -596,14 +599,30 @@ def _clean_inline_text(
     return text
 
 
-def _markdown_safe_text(value: Any, *, limit: int | None = None) -> str:
-    """Normalize and neutralize markdown/HTML control characters for inline prose."""
-    text = _clean_inline_text(value, limit=limit)
+def _markdown_safe_text(
+    value: Any,
+    *,
+    limit: int | None = None,
+    table_safe: bool = False,
+) -> str:
+    """Normalize inline text and neutralize Markdown control characters."""
+    text = _clean_inline_text(value, limit=limit, table_safe=table_safe)
     text = text.replace("\\", "\\\\")
     text = text.replace("<", "\\<").replace(">", "\\>")
     for token in ("#", "*", "_", "`", "[", "]", "(", ")", "!", "|"):
         text = text.replace(token, f"\\{token}")
     return text
+
+
+def _safe_markdown_url(value: Any) -> str:
+    """Return only http(s) URLs for markdown evidence appendix output."""
+    url = _clean_inline_text(value, table_safe=True)
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in {"http", "https"}:
+        return ""
+    return url
 
 
 def _humanize_token(value: str) -> str:

--- a/src/war_room/export_md.py
+++ b/src/war_room/export_md.py
@@ -90,7 +90,7 @@ def render_markdown_memo(
         lines.append("### Review Required")
         lines.append("")
         for flag in review_flags:
-            lines.append(f"- {flag}")
+            lines.append(f"- {_markdown_safe_text(flag, limit=220)}")
         lines.append("")
 
     lines.append("---")
@@ -442,7 +442,7 @@ def _append_sources(lines: list[str], sources: list[dict[str, Any]], label: str)
         lines.append(
             f"- {src.get('badge', '')} "
             f"[{_clean_inline_text(src.get('title', ''), limit=60)}]({src.get('url', '')})"
-            f" - {_clean_inline_text(src.get('reason', ''), limit=120)}"
+            f" - {_markdown_safe_text(src.get('reason', ''), limit=120)}"
         )
     lines.append("")
 
@@ -454,7 +454,7 @@ def _append_warnings(lines: list[str], warnings: list[str] | None, heading: str)
     lines.append(f"### {heading}")
     lines.append("")
     for warning in warnings:
-        lines.append(f"- {_clean_inline_text(warning, limit=180)}")
+        lines.append(f"- {_markdown_safe_text(warning, limit=180)}")
     lines.append("")
 
 
@@ -593,6 +593,16 @@ def _clean_inline_text(
         text = text.replace("|", "/")
     if limit is not None and len(text) > limit:
         return text[: max(0, limit - 3)].rstrip() + "..."
+    return text
+
+
+def _markdown_safe_text(value: Any, *, limit: int | None = None) -> str:
+    """Normalize and neutralize markdown/HTML control characters for inline prose."""
+    text = _clean_inline_text(value, limit=limit)
+    text = text.replace("\\", "\\\\")
+    text = text.replace("<", "\\<").replace(">", "\\>")
+    for token in ("#", "*", "_", "`", "[", "]", "(", ")", "!", "|"):
+        text = text.replace(token, f"\\{token}")
     return text
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -275,6 +275,18 @@ def test_render_surfaces_review_flags_when_present():
     assert "Evidence clusters: cluster-3" in md
 
 
+def test_render_escapes_markdown_in_review_flags_and_source_reasons():
+    intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
+    weather["warnings"] = ["## Injected heading <script>alert(1)</script> [click](https://evil)"]
+    weather["sources"][0]["reason"] = "![img](x) <img src=x onerror=alert(1)>"
+
+    md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
+
+    assert "\\#\\# Injected heading \\<script\\>alert\\(1\\)\\</script\\>" in md
+    assert "\\[click\\]\\(https://evil\\)" in md
+    assert "\\!\\[img\\]\\(x\\) \\<img src=x onerror=alert\\(1\\)\\>" in md
+
+
 def test_render_includes_evidence_clusters():
     md = render_markdown_memo(*_sample_data())
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,8 +6,13 @@ from pathlib import Path
 from war_room.carrier_module import build_carrier_doc_pack
 from war_room.caselaw_module import build_caselaw_pack
 from war_room.citation_verify import spot_check_citations
-from war_room.export_md import render_markdown_memo, write_markdown
-from war_room.models import CaseIntake, QuerySpec, citation_verify_pack_to_evidence_items
+from war_room.export_md import _append_review_log, render_markdown_memo, write_markdown
+from war_room.models import (
+    CaseIntake,
+    QuerySpec,
+    ReviewEvent,
+    citation_verify_pack_to_evidence_items,
+)
 from war_room.query_plan import generate_query_plan
 from war_room.weather_module import build_weather_brief
 
@@ -275,16 +280,24 @@ def test_render_surfaces_review_flags_when_present():
     assert "Evidence clusters: cluster-3" in md
 
 
-def test_render_escapes_markdown_in_review_flags_and_source_reasons():
+def test_render_escapes_markdown_in_review_flags_warnings_and_source_reasons():
     intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
     weather["warnings"] = ["## Injected heading <script>alert(1)</script> [click](https://evil)"]
     weather["sources"][0]["reason"] = "![img](x) <img src=x onerror=alert(1)>"
 
     md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
 
-    assert "\\#\\# Injected heading \\<script\\>alert\\(1\\)\\</script\\>" in md
-    assert "\\[click\\]\\(https://evil\\)" in md
-    assert "\\!\\[img\\]\\(x\\) \\<img src=x onerror=alert\\(1\\)\\>" in md
+    assert (
+        "- Weather: \\#\\# Injected heading &lt;script&gt;alert\\(1\\)&lt;/script&gt; "
+        "click\\(https://evil\\)"
+    ) in md
+    assert (
+        "- \\#\\# Injected heading &lt;script&gt;alert\\(1\\)&lt;/script&gt; "
+        "click\\(https://evil\\)"
+    ) in md
+    assert "\\!img\\(x\\) &lt;img src=x onerror=alert\\(1\\)&gt;" in md
+    assert "<script>" not in md
+    assert "<img src=x onerror=alert(1)>" not in md
 
 
 def test_render_includes_evidence_clusters():
@@ -357,6 +370,58 @@ def test_render_includes_canonical_evidence_index_rows():
     assert "caselaw-case-123-so-3d-456-" in md
     assert citation_evidence_id in md
     assert "| citation-check-1 |" not in md
+
+
+def test_render_sanitizes_evidence_index_review_log_and_unsafe_urls():
+    intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
+    weather["warnings"] = ["## Needs review [link](javascript:alert(2)) <b>"]
+    citecheck["checks"][0]["case_name"] = "Legit *Case* <b>"
+    citecheck["checks"][0]["badge"] = "verified|<script>"
+    citecheck["checks"][0]["source_url"] = "javascript:alert(1)"
+    citecheck["checks"][0]["status"] = "uncertain"
+    citecheck["summary"] = {"total": 1, "verified": 0, "uncertain": 1, "not_found": 0}
+    citation_evidence_id = citation_verify_pack_to_evidence_items(citecheck)[0].evidence_id
+
+    md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
+    evidence_index = md.split("## Appendix: Evidence Index", 1)[1].split(
+        "## Appendix: Review Log", 1
+    )[0]
+
+    assert (
+        f"| {citation_evidence_id} | citation_verify | citation_check | "
+        "Legit \\*Case\\* &lt;b&gt; | verified/&lt;script&gt; |  |"
+    ) in evidence_index
+    assert (
+        "**Weather review required:** \\#\\# Needs review "
+        "link\\(javascript:alert\\(2\\)\\) &lt;b&gt;"
+    ) in md
+    assert "javascript:alert(1)" not in evidence_index
+    assert "<script>" not in evidence_index
+    assert "<b>" not in md
+
+
+def test_append_review_log_escapes_label_and_detail_fields():
+    lines: list[str] = []
+    _append_review_log(
+        lines,
+        [
+            ReviewEvent(
+                event_id="review-injection",
+                event_type="warning",
+                label="**Injected** <b>",
+                detail="[link](javascript:alert(1)) <img>",
+                related_cluster_ids=["cluster-1"],
+            )
+        ],
+    )
+
+    rendered = "\n".join(lines)
+
+    assert (
+        "- **\\*\\*Injected\\*\\* &lt;b&gt;:** "
+        "link\\(javascript:alert\\(1\\)\\) &lt;img&gt; "
+        "| Evidence clusters: cluster-1"
+    ) in rendered
 
 
 def test_render_accepts_dict_intake_and_query_specs():


### PR DESCRIPTION
### Motivation
- A top-of-memo `Review Required` block plus per-module warning and source `reason` fields were being written verbatim into generated Markdown, creating a Markdown/HTML injection surface. 
- The change aims to neutralize untrusted `warnings` and `reason` strings so a malicious cache/fixture cannot inject headings, links, images, or script-bearing HTML into exported memos. 

### Description
- Added a small helper ` _markdown_safe_text(...)` that normalizes inline text and escapes Markdown and HTML control characters. 
- Applied ` _markdown_safe_text(...)` when emitting top-level review flags, module warning list items, and source `reason` inline text in `render_markdown_memo` paths. 
- Added a focused regression test `test_render_escapes_markdown_in_review_flags_and_source_reasons` in `tests/test_export.py` that asserts injected headings, links, and HTML are emitted escaped. 
- Changes are narrow and preserve existing payload shapes and contracts; no schema or dependency changes were introduced. 

### Testing
- Ran `git diff --check` in the workspace and it passed. 
- Attempted `python -m pytest tests/test_export.py -q` but the raw container environment could not import the package (module resolution error); this is expected without an editable install. 
- Attempted `PYTHONPATH=src python -m pytest tests/test_export.py -q` but the run was blocked by a missing runtime dependency (`pydantic`) in the container, so the local pytest run could not complete here. 
- Note: a full verification should be run in the supported contributor flow (`pip install -r requirements.txt` + `pip install -e . --no-deps` then `python -m war_room --verify` or `pytest -q`) to confirm the new test and the larger suite pass in a bootstrapped environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaac57e48320bc9ba2e2d7b08c62)