### PR TITLE
fix(ci): pin setuptools in GitHub Actions workflows to reduce supply-chain risk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
 
@@ -76,7 +76,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
 
@@ -139,7 +139,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
 
@@ -224,7 +224,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
 
@@ -280,7 +280,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install -r requirements.txt
           pip install -e . --no-deps --no-build-isolation
 

--- a/.github/workflows/exa-compat-matrix.yml
+++ b/.github/workflows/exa-compat-matrix.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Test Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "setuptools>=69"
+          pip install "setuptools==69.5.1"
           pip install python-dotenv==1.0.1 nbformat==5.10.4 pytest==8.3.4 pydantic==2.11.7
           pip install "${{ matrix.exa_spec }}"
           pip install -e . --no-deps --no-build-isolation


### PR DESCRIPTION
### Motivation
- Harden CI against supply-chain risk by avoiding a floating `setuptools>=69` install immediately before `pip install -e . --no-deps --no-build-isolation`, which can cause an unreviewed build backend to execute in CI.

### Description
- Replaced `pip install "setuptools>=69"` with an exact pin `pip install "setuptools==69.5.1"` in `.github/workflows/ci.yml` and `.github/workflows/exa-compat-matrix.yml` to prevent automatic uptake of future setuptools releases while preserving the existing editable-install flow.

### Testing
- Ran `git diff --check` which passed; attempts to run the repo `--verify` flow in this container failed because the package is not installed (`python -m war_room --verify`) and `PYTHONPATH=src python -m war_room --verify` failed due to a missing `python-dotenv` dependency, so full test/verify could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaaacfbc83209b8bedcca4e413b1)