### PR TITLE
ci: pin legacy exa matrix version and tighten GitHub Actions permissions

### DIFF
--- a/.github/workflows/exa-compat-matrix.yml
+++ b/.github/workflows/exa-compat-matrix.yml
@@ -10,6 +10,9 @@ on:
       - codex/**
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   exa-matrix:
     name: exa-py (${{ matrix.exa_spec }})
@@ -20,11 +23,13 @@ jobs:
         include:
           - exa_spec: "exa-py==2.0.2"
             exa_label: "exa-py-2-0-2"
-          - exa_spec: "exa-py<2"
-            exa_label: "exa-py-lt-2"
+          - exa_spec: "exa-py==1.14.0"
+            exa_label: "exa-py-1-14-0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Milton, Ida, Ian, and both Texas hail benchmarks now map from the curated notebo
 - Fresh environment install + full test run with categorized unit-test gate artifacts
 - Editable package bootstrap validation
 - Offline fixture smoke validation plus the committed golden fixture snapshot check across committed scenarios, with separate offline-fixture and golden-snapshot gate artifacts
-- `exa-py` compatibility matrix (`exa-py==2.0.2` and `exa-py<2`) with categorized compatibility artifacts
+- `exa-py` compatibility matrix (`exa-py==2.0.2` and `exa-py==1.14.0`) with categorized compatibility artifacts
 - Release-scorecard artifact emission plus ship-threshold validation from the calibrated `#27` workflow, with separate generation and validation gate artifacts
 - Offline security hygiene validation for committed env files, obvious API key patterns, `.env.example` expectations, runtime artifact commits, and documented secrets policy drift, with categorized security artifacts
 - Offline dependency hygiene validation for pinned requirements, disallowed editable/local/direct-URL dependencies, duplicate/conflicting entries, `requirements.txt` / `pyproject.toml` drift, unsupported dependency files, and documented dependency policy drift

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -43,7 +43,7 @@ This is research acceleration, not legal advice.
 - Exa client now supports both older and newer `exa-py` contents APIs.
 - Dependency versions are pinned for reproducible installs.
 - CI now blocks merges if fresh-env tests fail.
-- CI also runs an `exa-py` compatibility matrix (`exa-py==2.0.2` and `exa-py<2`).
+- CI also runs an `exa-py` compatibility matrix (`exa-py==2.0.2` and `exa-py==1.14.0`).
 - Adapter smoke tests were added for kwargs forwarding contracts.
 - Intake JSON now has strict schema validation and file-loading helpers.
 - Typed domain contracts now cover intake/query, weather/carrier/caselaw packs, and citation/export memo contracts.


### PR DESCRIPTION
### Motivation
- The Exa compatibility workflow allowed a broad runtime resolution (`exa-py<2`) which could install an unreviewed/compromised legacy release and execute code in CI. 
- The workflow also used default checkout credentials and did not explicitly scope `GITHUB_TOKEN`, increasing potential impact of any supply-chain compromise.

### Description
- Replace the broad matrix entry `exa-py<2` with a reviewed exact pin `exa-py==1.14.0` to avoid unbounded legacy resolution. 
- Add minimal top-level workflow permissions `permissions: contents: read` to reduce token scope during runs. 
- Disable persisted checkout credentials by setting `persist-credentials: false` on the `actions/checkout@v4` step. 
- Update documentation references to the Exa compatibility matrix entries in `README.md` and `docs/HANDOFF.md` for consistency with the workflow change.

### Testing
- Ran `git diff --check` which reported no whitespace/patch issues and passed. 
- Attempted `python -m war_room --verify` but it failed in the current container with `No module named war_room` because the editable package was not installed in this environment. 
- Attempted `PYTHONPATH=src python -m pytest -q` but collection failed due to missing test dependencies (`pydantic`, `python-dotenv`, `exa_py`) in the ephemeral container, so the full test suite could not be executed here. 
- Recommendation: run the supported local bootstrap (`pip install -r requirements.txt && pip install -e . --no-deps --no-build-isolation`) and then re-run `python -m war_room --verify` and `pytest -q` to validate the change in a fully provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dcaab6c0c8320b81778cb8789bb86)