### PR TITLE
[codex] Add provenance-integrity harness

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3193,3 +3193,39 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `484 passed in 18.45s`; verify manifest written under
     `runs/verify/2026-05-20_codex-issue-12-dedupe-plan_20260520t204851z.json`.
+
+## Session 141 - Issue 134 Provenance Integrity Harness
+Date: 2026-05-20
+Status: Complete
+
+- Added a test-only provenance-integrity harness before any audit-snapshot
+  dedupe wiring.
+- What changed:
+  - Added shared test helpers that assert audit snapshots have no dangling
+    evidence IDs in clusters, memo claims, or review events, and no dangling
+    cluster IDs in memo claims or review events.
+  - Extended Evidence Board, Issue Workspace, Memo Composer, Markdown export,
+    and committed fixture preflight tests so current read-model/export
+    references resolve back to the fixture-backed audit snapshot.
+  - Added a cross-module caselaw/citation-verification regression shape where
+    both rows reference the same authority/URL, remain distinct evidence rows,
+    and the harness catches an orphaned citation-verification row.
+- Decisions added:
+  - Provenance-integrity checks should land before runtime dedupe integration
+    and should treat current cross-module caselaw/citation-verification rows as
+    related by cluster but not collapsed into one evidence row.
+- Decisions not added:
+  - no runtime behavior change, dedupe integration,
+    `old_id -> retained_id` remapping, schema change, golden snapshot refresh,
+    persistence, API, UI, dashboard, auth, queues, workers, fuzzy/ML
+    clustering, AI scoring, citation-search behavior change, or
+    citation-verification behavior change was added.
+- Validation:
+  - `python -m pytest tests/test_memo_contracts.py::test_provenance_harness_preserves_distinct_cross_module_authority_rows tests/test_preflight.py::test_committed_fixture_preflight_surfaces_keep_provenance_integrity tests/test_export.py::test_rendered_markdown_provenance_references_resolve_to_snapshot -q`
+    -> `3 passed in 2.11s`.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export.py tests/test_preflight.py -q`
+    -> `83 passed in 3.93s`.
+  - `git diff --check` -> passed.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `487 passed in 16.78s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-134-provenance-integrity-harness_20260520t214235z.json`.

--- a/tests/provenance_integrity.py
+++ b/tests/provenance_integrity.py
@@ -1,0 +1,322 @@
+"""Shared provenance-integrity assertions for audit snapshots and read models."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from war_room.carrier_module import build_carrier_doc_pack
+from war_room.caselaw_module import build_caselaw_pack
+from war_room.export_md import render_markdown_memo
+from war_room.evidence_board import build_evidence_board
+from war_room.issue_workspace import build_issue_workspace
+from war_room.memo_composer import build_memo_composer
+from war_room.models import (
+    EvidenceBoardReadModel,
+    IssueWorkspaceReadModel,
+    MemoComposerReadModel,
+    QuerySpec,
+    RunAuditSnapshot,
+    adapt_evidence_board,
+    adapt_issue_workspace,
+    adapt_memo_composer,
+    adapt_run_audit_snapshot,
+    run_audit_snapshot_from_parts,
+)
+from war_room.query_plan import generate_query_plan, load_case_intake
+from war_room.scenarios import load_scenario_for_fixture_case
+from war_room.weather_module import build_weather_brief
+
+_REQUIRED_FIXTURE_FILES = ("weather.json", "carrier.json", "caselaw.json", "citation_verify.json")
+_CLUSTER_ID_RE = re.compile(r"\bcluster-\d+\b")
+
+
+def committed_fixture_case_keys(repo_root: Path) -> list[str]:
+    """Return fixture case keys that have the complete offline module bundle."""
+
+    cache_samples_dir = repo_root / "cache_samples"
+    return [
+        scenario_dir.name
+        for scenario_dir in sorted(path for path in cache_samples_dir.iterdir() if path.is_dir())
+        if all((scenario_dir / name).exists() for name in _REQUIRED_FIXTURE_FILES)
+    ]
+
+
+def fixture_parts(repo_root: Path, case_key: str) -> tuple[Any, Any, Any, Any, Any, list[QuerySpec]]:
+    """Build current notebook-era module outputs from committed fixtures only."""
+
+    cache_samples_dir = repo_root / "cache_samples"
+    scenario = load_scenario_for_fixture_case(case_key, repo_root=repo_root)
+    intake = (
+        scenario.to_case_intake()
+        if scenario is not None
+        else load_case_intake(repo_root / "eval" / "intakes" / f"{case_key}.json")
+    )
+    query_plan = generate_query_plan(intake)
+    weather = build_weather_brief(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=str(cache_samples_dir),
+    )
+    carrier = build_carrier_doc_pack(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=str(cache_samples_dir),
+    )
+    caselaw = build_caselaw_pack(
+        intake,
+        None,
+        query_plan=query_plan,
+        cache_samples_dir=str(cache_samples_dir),
+    )
+    citecheck = json.loads(
+        (cache_samples_dir / case_key / "citation_verify.json").read_text(encoding="utf-8")
+    )
+    return intake, weather, carrier, caselaw, citecheck, query_plan
+
+
+def fixture_audit_snapshot(repo_root: Path, case_key: str) -> RunAuditSnapshot:
+    """Build the fixture-backed audit snapshot used by the current read models."""
+
+    return run_audit_snapshot_from_parts(*fixture_parts(repo_root, case_key))
+
+
+def fixture_markdown(repo_root: Path, case_key: str) -> str:
+    """Render fixture-backed markdown through the current export path."""
+
+    return render_markdown_memo(*fixture_parts(repo_root, case_key))
+
+
+def fixture_snapshot_and_markdown(repo_root: Path, case_key: str) -> tuple[RunAuditSnapshot, str]:
+    """Build the fixture-backed audit snapshot and markdown from one payload set."""
+
+    parts = fixture_parts(repo_root, case_key)
+    return run_audit_snapshot_from_parts(*parts), render_markdown_memo(*parts)
+
+
+def assert_audit_snapshot_provenance_integrity(
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+) -> None:
+    """Assert audit snapshot evidence and cluster references resolve."""
+
+    snapshot = adapt_run_audit_snapshot(snapshot)
+    evidence_ids = [item.evidence_id for item in snapshot.evidence_items]
+    cluster_ids = [cluster.cluster_id for cluster in snapshot.evidence_clusters]
+    evidence_id_set = set(evidence_ids)
+    cluster_id_set = set(cluster_ids)
+
+    assert len(evidence_ids) == len(evidence_id_set), "duplicate evidence IDs in audit snapshot"
+    assert len(cluster_ids) == len(cluster_id_set), "duplicate cluster IDs in audit snapshot"
+
+    for cluster in snapshot.evidence_clusters:
+        _assert_known_ids(
+            f"cluster {cluster.cluster_id} evidence_ids",
+            cluster.evidence_ids,
+            evidence_id_set,
+        )
+        assert cluster.member_count == len(cluster.evidence_ids), (
+            f"cluster {cluster.cluster_id} member_count does not match evidence_ids"
+        )
+
+    for claim in snapshot.memo_claims:
+        _assert_known_ids(
+            f"memo claim {claim.claim_id} evidence_ids",
+            claim.evidence_ids,
+            evidence_id_set,
+        )
+        _assert_known_ids(
+            f"memo claim {claim.claim_id} cluster_ids",
+            claim.cluster_ids,
+            cluster_id_set,
+        )
+
+    for event in snapshot.review_events:
+        _assert_known_ids(
+            f"review event {event.event_id} related_evidence_ids",
+            event.related_evidence_ids,
+            evidence_id_set,
+        )
+        _assert_known_ids(
+            f"review event {event.event_id} related_cluster_ids",
+            event.related_cluster_ids,
+            cluster_id_set,
+        )
+
+    quality = snapshot.quality_snapshot
+    assert quality.evidence_item_count == len(snapshot.evidence_items)
+    assert quality.evidence_cluster_count == len(snapshot.evidence_clusters)
+    assert quality.provenance_link_count == sum(
+        len(cluster.provenance_urls) for cluster in snapshot.evidence_clusters
+    )
+
+
+def assert_evidence_board_provenance_integrity(
+    board: Mapping[str, Any] | EvidenceBoardReadModel,
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+) -> None:
+    """Assert Evidence Board read-model references resolve to the snapshot."""
+
+    board = adapt_evidence_board(board)
+    evidence_ids, cluster_ids = _snapshot_id_sets(snapshot)
+    _assert_known_ids(
+        "Evidence Board cluster cards",
+        (card.cluster_id for card in board.cluster_cards),
+        cluster_ids,
+    )
+    _assert_known_ids(
+        "Evidence Board preview evidence IDs",
+        (
+            preview.evidence_id
+            for card in board.cluster_cards
+            for preview in card.evidence_previews
+        ),
+        evidence_ids,
+    )
+    _assert_known_ids(
+        "Evidence Board ungrouped evidence IDs",
+        (preview.evidence_id for preview in board.ungrouped_items),
+        evidence_ids,
+    )
+
+
+def assert_issue_workspace_provenance_integrity(
+    workspace: Mapping[str, Any] | IssueWorkspaceReadModel,
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+) -> None:
+    """Assert Issue Workspace read-model references resolve to the snapshot."""
+
+    workspace = adapt_issue_workspace(workspace)
+    evidence_ids, cluster_ids = _snapshot_id_sets(snapshot)
+    _assert_known_ids(
+        "Issue Workspace evidence cluster IDs",
+        (
+            cluster_id
+            for card in workspace.issue_cards
+            for cluster_id in card.evidence_cluster_ids
+        ),
+        cluster_ids,
+    )
+    _assert_known_ids(
+        "Issue Workspace case-candidate evidence IDs",
+        (
+            candidate.evidence_id
+            for card in workspace.issue_cards
+            for candidate in card.case_candidates
+        ),
+        evidence_ids,
+    )
+    _assert_known_ids(
+        "Issue Workspace citation-outcome evidence IDs",
+        (
+            outcome.evidence_id
+            for card in workspace.issue_cards
+            for outcome in card.citation_outcomes
+        ),
+        evidence_ids,
+    )
+
+
+def assert_memo_composer_provenance_integrity(
+    composer: Mapping[str, Any] | MemoComposerReadModel,
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+) -> None:
+    """Assert Memo Composer read-model claim links resolve to the snapshot."""
+
+    composer = adapt_memo_composer(composer)
+    evidence_ids, cluster_ids = _snapshot_id_sets(snapshot)
+    _assert_known_ids(
+        "Memo Composer claim-link evidence IDs",
+        (
+            evidence_id
+            for section in composer.section_cards
+            for claim in section.claim_links
+            for evidence_id in claim.evidence_ids
+        ),
+        evidence_ids,
+    )
+    _assert_known_ids(
+        "Memo Composer claim-link cluster IDs",
+        (
+            cluster_id
+            for section in composer.section_cards
+            for claim in section.claim_links
+            for cluster_id in claim.cluster_ids
+        ),
+        cluster_ids,
+    )
+
+
+def assert_markdown_provenance_integrity(
+    markdown: str,
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+) -> None:
+    """Assert rendered markdown contains only current snapshot IDs."""
+
+    snapshot = adapt_run_audit_snapshot(snapshot)
+    evidence_ids, cluster_ids = _snapshot_id_sets(snapshot)
+    evidence_refs = set(_markdown_evidence_index_ids(markdown))
+    cluster_refs = set(_CLUSTER_ID_RE.findall(markdown))
+
+    _assert_known_ids("Markdown evidence references", evidence_refs, evidence_ids)
+    _assert_known_ids("Markdown cluster references", cluster_refs, cluster_ids)
+
+    _assert_known_ids(
+        "Markdown Evidence Index rows",
+        (item.evidence_id for item in snapshot.evidence_items),
+        evidence_refs,
+    )
+    _assert_known_ids(
+        "Markdown cluster rows",
+        (cluster.cluster_id for cluster in snapshot.evidence_clusters),
+        cluster_refs,
+    )
+
+
+def assert_all_current_provenance_surfaces(
+    snapshot: Mapping[str, Any] | RunAuditSnapshot,
+    markdown: str,
+) -> None:
+    """Assert the current audit, read-model, and markdown provenance surfaces."""
+
+    snapshot = adapt_run_audit_snapshot(snapshot)
+    assert_audit_snapshot_provenance_integrity(snapshot)
+    assert_evidence_board_provenance_integrity(build_evidence_board(snapshot), snapshot)
+    assert_issue_workspace_provenance_integrity(build_issue_workspace(snapshot), snapshot)
+    assert_memo_composer_provenance_integrity(build_memo_composer(snapshot), snapshot)
+    assert_markdown_provenance_integrity(markdown, snapshot)
+
+
+def _snapshot_id_sets(snapshot: Mapping[str, Any] | RunAuditSnapshot) -> tuple[set[str], set[str]]:
+    snapshot = adapt_run_audit_snapshot(snapshot)
+    evidence_ids = {item.evidence_id for item in snapshot.evidence_items}
+    cluster_ids = {cluster.cluster_id for cluster in snapshot.evidence_clusters}
+    return evidence_ids, cluster_ids
+
+
+def _markdown_evidence_index_ids(markdown: str) -> list[str]:
+    if "## Appendix: Evidence Index" not in markdown:
+        return []
+    section = markdown.split("## Appendix: Evidence Index", 1)[1]
+    next_section = section.find("\n## ")
+    if next_section != -1:
+        section = section[:next_section]
+
+    evidence_ids: list[str] = []
+    for line in section.splitlines():
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if not cells or cells[0] == "ID" or set(cells[0]) <= {"-"}:
+            continue
+        evidence_ids.append(cells[0])
+    return evidence_ids
+
+
+def _assert_known_ids(label: str, refs: Any, known_ids: set[str]) -> None:
+    ref_set = {ref for ref in refs if ref}
+    missing = sorted(ref_set - known_ids)
+    assert not missing, f"{label} reference missing IDs: {', '.join(missing)}"

--- a/tests/test_evidence_board.py
+++ b/tests/test_evidence_board.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from tests.provenance_integrity import assert_evidence_board_provenance_integrity
 from war_room.evidence_board import (
     build_evidence_board,
     build_evidence_board_from_parts,
@@ -145,6 +146,7 @@ def test_build_evidence_board_links_claims_and_review_events_to_clusters():
     assert first_card.review_event_ids
     assert first_card.claim_ids
     assert first_card.evidence_previews
+    assert_evidence_board_provenance_integrity(board, snapshot)
 
 
 def test_build_evidence_board_from_parts_matches_snapshot_builder():

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -12,9 +12,11 @@ from war_room.models import (
     QuerySpec,
     ReviewEvent,
     citation_verify_pack_to_evidence_items,
+    run_audit_snapshot_from_parts,
 )
 from war_room.query_plan import generate_query_plan
 from war_room.weather_module import build_weather_brief
+from tests.provenance_integrity import assert_markdown_provenance_integrity
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -370,6 +372,14 @@ def test_render_includes_canonical_evidence_index_rows():
     assert "caselaw-case-123-so-3d-456-" in md
     assert citation_evidence_id in md
     assert "| citation-check-1 |" not in md
+
+
+def test_rendered_markdown_provenance_references_resolve_to_snapshot():
+    sample_data = _sample_data()
+    snapshot = run_audit_snapshot_from_parts(*sample_data)
+    md = render_markdown_memo(*sample_data)
+
+    assert_markdown_provenance_integrity(md, snapshot)
 
 
 def test_render_sanitizes_evidence_index_review_log_and_unsafe_urls():

--- a/tests/test_issue_workspace.py
+++ b/tests/test_issue_workspace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from tests.provenance_integrity import assert_issue_workspace_provenance_integrity
 from war_room.issue_workspace import (
     build_issue_workspace,
     build_issue_workspace_from_parts,
@@ -174,6 +175,7 @@ def test_build_issue_workspace_links_clusters_claims_and_citation_outcomes():
     assert second_card.issue_label == "scope of repair"
     assert second_card.review_required is False
     assert second_card.citation_outcomes[0].status == "verified"
+    assert_issue_workspace_provenance_integrity(workspace, snapshot)
 
 
 def test_build_issue_workspace_from_parts_matches_snapshot_builder():

--- a/tests/test_memo_composer.py
+++ b/tests/test_memo_composer.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from tests.provenance_integrity import assert_memo_composer_provenance_integrity
 from war_room.memo_composer import (
     build_memo_composer,
     build_memo_composer_from_parts,
@@ -139,6 +140,7 @@ def test_build_memo_composer_links_claims_to_sections_and_export_state():
     assert weather_section.review_required is True
     assert weather_section.claim_links
     assert weather_section.review_event_ids
+    assert_memo_composer_provenance_integrity(composer, snapshot)
 
 
 def test_build_memo_composer_from_parts_matches_snapshot_builder():

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -5,6 +5,7 @@ import copy
 import pytest
 from pydantic import ValidationError
 
+from tests.provenance_integrity import assert_audit_snapshot_provenance_integrity
 from war_room.export_md import render_markdown_memo
 from war_room.models import (
     CaseIntake,
@@ -822,6 +823,7 @@ def test_run_audit_snapshot_builds_canonical_entities():
     assert snapshot.evidence_clusters[2].provenance_urls == ["https://example.com/case"]
     assert payload["memo_claims"][3]["cluster_ids"] == ["cluster-3"]
     assert payload["export_artifact"]["artifact_id"].endswith(":artifact:markdown-memo")
+    assert_audit_snapshot_provenance_integrity(snapshot)
 
 
 def test_run_audit_snapshot_tracks_review_events_and_claim_status():
@@ -1090,3 +1092,44 @@ def test_run_audit_snapshot_tracks_duplicate_authority_counts_when_case_and_chec
     assert snapshot.quality_snapshot.duplicate_authority_count == 1
     assert snapshot.quality_snapshot.provenance_link_count == 4
     assert snapshot.evidence_clusters[2].provenance_urls == ["https://example.com/case", "https://alt.example.com/case"]
+
+
+def test_provenance_harness_preserves_distinct_cross_module_authority_rows():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    citecheck["checks"][0]["status"] = "uncertain"
+    citecheck["checks"][0]["badge"] = "warning"
+    citecheck["checks"][0]["note"] = "Found on reviewable source."
+    citecheck["summary"] = {"total": 1, "verified": 0, "uncertain": 1, "not_found": 0}
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
+    citation_evidence_id = citation_verify_pack_to_evidence_items(citecheck)[0].evidence_id
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    assert caselaw_evidence_id != citation_evidence_id
+    shared_cluster = next(
+        cluster
+        for cluster in snapshot.evidence_clusters
+        if caselaw_evidence_id in cluster.evidence_ids
+        and citation_evidence_id in cluster.evidence_ids
+    )
+    assert shared_cluster.modules == ["caselaw", "citation_verify"]
+    assert_audit_snapshot_provenance_integrity(snapshot)
+
+    orphaned_snapshot = snapshot.model_copy(
+        update={
+            "evidence_items": [
+                item
+                for item in snapshot.evidence_items
+                if item.evidence_id != citation_evidence_id
+            ]
+        }
+    )
+    with pytest.raises(AssertionError, match=citation_evidence_id):
+        assert_audit_snapshot_provenance_integrity(orphaned_snapshot)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tests.provenance_integrity import (
+    assert_all_current_provenance_surfaces,
+    committed_fixture_case_keys,
+    fixture_snapshot_and_markdown,
+)
 from war_room.bootstrap import bootstrap_runtime, main as bootstrap_main
 from war_room.preflight import (
     preflight_run_id,
@@ -65,6 +70,13 @@ def test_demo_preflight_smoke_covers_committed_scenarios():
         assert scenario.memo_length > 0
         assert len(scenario.memo_sections) == 10
     assert all("Registry scenario" in scenario.availability.detail for scenario in report.scenarios)
+
+
+def test_committed_fixture_preflight_surfaces_keep_provenance_integrity():
+    for case_key in committed_fixture_case_keys(ROOT):
+        snapshot, markdown = fixture_snapshot_and_markdown(ROOT, case_key)
+
+        assert_all_current_provenance_surfaces(snapshot, markdown)
 
 
 def test_demo_preflight_rendering_includes_summary():


### PR DESCRIPTION
## Summary

- Adds shared test-only provenance-integrity assertions for audit snapshots, read models, and markdown export surfaces.
- Covers current fixture-backed outputs across Evidence Board, Issue Workspace, Memo Composer, Markdown export, and preflight fixture surfaces.
- Adds a cross-module caselaw/citation-verification regression shape proving same-authority rows remain distinct for now and that orphaned citation-check evidence is caught.

## Runtime behavior

No runtime behavior changes. This PR does not wire `dedupe_evidence_items(...)` into audit snapshot assembly and does not add `old_id -> retained_id` remapping.

## Validation

- `python -m pytest tests/test_memo_contracts.py::test_provenance_harness_preserves_distinct_cross_module_authority_rows tests/test_preflight.py::test_committed_fixture_preflight_surfaces_keep_provenance_integrity tests/test_export.py::test_rendered_markdown_provenance_references_resolve_to_snapshot -q` -> `3 passed in 2.11s`
- `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export.py tests/test_preflight.py -q` -> `83 passed in 3.93s`
- `git diff --check` -> passed
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `487 passed in 16.78s`

## Non-goals preserved

No runtime dedupe integration, schema changes, golden snapshot refresh, persistence, API, UI, dashboard, auth, queues, workers, fuzzy/ML clustering, AI scoring, citation-search changes, or citation-verification behavior changes.

Closes #134.