### PR TITLE
Integrate same-module audit-snapshot dedupe

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3229,3 +3229,46 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `487 passed in 16.78s`; verify manifest written under
     `runs/verify/2026-05-20_codex-134-provenance-integrity-harness_20260520t214235z.json`.
+
+## Session 142 - Issue 12 Same-Module Audit Snapshot Dedupe
+Date: 2026-05-20
+Status: Complete
+
+- Wired deterministic same-module evidence dedupe into audit snapshot assembly
+  behind an explicit runtime-local `old_id -> retained_id` remapping contract.
+- What changed:
+  - Added an internal dedupe integration result in `src/war_room/models.py`
+    with retained items, old-to-retained ID mapping, removed duplicate IDs, and
+    retained-to-duplicate ID mapping.
+  - Applied dedupe only after weather, carrier, caselaw, and citation-verify
+    adapters emit current `EvidenceItem` rows, and only with same-module keys.
+  - Rebuilt module evidence ID lists, evidence clusters, memo claims, citation
+    review-event links, and quality counts from retained IDs so removed
+    duplicate IDs do not leak into downstream surfaces.
+  - Added focused tests for deterministic retained IDs, same-module collapse,
+    cross-module non-collapse, citation-review remapping, markdown/read-model
+    provenance integrity, and raw-vs-retained evidence counts.
+- Decisions added:
+  - Audit snapshot dedupe is same-module only; caselaw and citation-verification
+    rows that share a URL or citation remain separate evidence rows and may
+    still share a cluster.
+  - `raw_evidence_count` tracks pre-dedupe adapter rows while
+    `evidence_item_count` tracks retained exported evidence rows.
+- Decisions not added:
+  - no persistence, API, UI/dashboard, auth/users/sessions, queues/workers,
+    schema expansion, fuzzy/ML clustering, AI scoring, live retrieval changes,
+    citation verification behavior change, golden snapshot refresh, or claim
+    that the V2 evidence graph is complete was added.
+- Counts:
+  - Focused synthetic duplicate tests now show `raw_evidence_count=5` and
+    `evidence_item_count=4` after same-module collapse.
+  - Current committed fixture lanes showed no same-module duplicate collapse:
+    raw and retained evidence counts were equal across all five fixture cases.
+- Validation:
+  - `git diff --check` -> passed.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export.py tests/test_preflight.py -q`
+    -> `87 passed in 6.29s`.
+  - `python -m pytest -q` -> `491 passed in 21.40s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `491 passed in 22.10s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-12-same-module-audit-dedupe_20260520t220446z.json`.

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import re
+from dataclasses import dataclass
 from typing import Any, Literal, Mapping, Sequence
 from urllib.parse import parse_qsl, urlencode, urlparse
 
@@ -633,6 +634,14 @@ class RunAuditSnapshot(BaseModel):
         return _validate_schema_version(value)
 
 
+@dataclass(frozen=True)
+class _EvidenceDedupeIntegrationResult:
+    retained_items: list[EvidenceItem]
+    old_id_to_retained_id: dict[str, str]
+    removed_duplicate_ids: list[str]
+    retained_id_to_duplicate_ids: dict[str, list[str]]
+
+
 class EvidenceBoardItemPreview(BaseModel):
     """Compact evidence-item preview for board rendering."""
 
@@ -1259,23 +1268,69 @@ def dedupe_evidence_items(evidence_items: Sequence[EvidenceItem]) -> list[Eviden
     earlier retained row when the selected review/provenance compatibility
     fields checked by this helper remain compatible.
     """
+    return _dedupe_evidence_items_with_result(
+        evidence_items,
+        same_module_only=False,
+    ).retained_items
+
+
+def _dedupe_evidence_items_for_audit_snapshot(
+    evidence_items: Sequence[EvidenceItem],
+) -> _EvidenceDedupeIntegrationResult:
+    return _dedupe_evidence_items_with_result(
+        evidence_items,
+        same_module_only=True,
+    )
+
+
+def _dedupe_evidence_items_with_result(
+    evidence_items: Sequence[EvidenceItem],
+    *,
+    same_module_only: bool,
+) -> _EvidenceDedupeIntegrationResult:
     retained_by_key: dict[tuple[str, ...], list[EvidenceItem]] = {}
-    deduped: list[EvidenceItem] = []
+    retained_result_items: list[EvidenceItem] = []
+    old_id_to_retained_id: dict[str, str] = {}
+    removed_duplicate_ids: list[str] = []
+    retained_id_to_duplicate_ids: dict[str, list[str]] = {}
 
     for item in evidence_items:
         key = _dedupe_key_for_evidence_item(item)
         if key is None:
-            deduped.append(item)
+            retained_result_items.append(item)
+            old_id_to_retained_id[item.evidence_id] = item.evidence_id
+            continue
+        if same_module_only:
+            key = (item.module, *key)
+
+        key_retained_items = retained_by_key.setdefault(key, [])
+        retained_match = next(
+            (
+                retained
+                for retained in key_retained_items
+                if _evidence_items_can_collapse(retained, item)
+            ),
+            None,
+        )
+        if retained_match is not None:
+            old_id_to_retained_id[item.evidence_id] = retained_match.evidence_id
+            removed_duplicate_ids.append(item.evidence_id)
+            retained_id_to_duplicate_ids.setdefault(
+                retained_match.evidence_id,
+                [],
+            ).append(item.evidence_id)
             continue
 
-        retained_items = retained_by_key.setdefault(key, [])
-        if any(_evidence_items_can_collapse(retained, item) for retained in retained_items):
-            continue
+        key_retained_items.append(item)
+        retained_result_items.append(item)
+        old_id_to_retained_id[item.evidence_id] = item.evidence_id
 
-        retained_items.append(item)
-        deduped.append(item)
-
-    return deduped
+    return _EvidenceDedupeIntegrationResult(
+        retained_items=retained_result_items,
+        old_id_to_retained_id=old_id_to_retained_id,
+        removed_duplicate_ids=removed_duplicate_ids,
+        retained_id_to_duplicate_ids=retained_id_to_duplicate_ids,
+    )
 
 
 def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditSnapshot:
@@ -1292,7 +1347,7 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
     )
 
     evidence_items: list[EvidenceItem] = []
-    evidence_ids_by_module = {
+    raw_evidence_ids_by_module = {
         "weather": [],
         "carrier": [],
         "caselaw": [],
@@ -1301,30 +1356,46 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
 
     weather_evidence_items = weather_brief_to_evidence_items(memo_input.weather)
     evidence_items.extend(weather_evidence_items)
-    evidence_ids_by_module["weather"].extend(
+    raw_evidence_ids_by_module["weather"].extend(
         item.evidence_id for item in weather_evidence_items
     )
 
     carrier_evidence_items = carrier_doc_pack_to_evidence_items(memo_input.carrier)
     evidence_items.extend(carrier_evidence_items)
-    evidence_ids_by_module["carrier"].extend(
+    raw_evidence_ids_by_module["carrier"].extend(
         item.evidence_id for item in carrier_evidence_items
     )
 
     caselaw_evidence_items = caselaw_pack_to_evidence_items(memo_input.caselaw)
     evidence_items.extend(caselaw_evidence_items)
-    evidence_ids_by_module["caselaw"].extend(
+    raw_evidence_ids_by_module["caselaw"].extend(
         item.evidence_id for item in caselaw_evidence_items
     )
 
     citation_evidence_items = citation_verify_pack_to_evidence_items(memo_input.citecheck)
     evidence_items.extend(citation_evidence_items)
-    evidence_ids_by_module["citation_verify"].extend(
+    raw_evidence_ids_by_module["citation_verify"].extend(
         item.evidence_id for item in citation_evidence_items
     )
 
+    raw_evidence_count = len(evidence_items)
+    dedupe_result = _dedupe_evidence_items_for_audit_snapshot(evidence_items)
+    evidence_items = dedupe_result.retained_items
+    evidence_ids_by_module = {
+        module: _rewrite_evidence_ids(
+            evidence_ids,
+            dedupe_result.old_id_to_retained_id,
+        )
+        for module, evidence_ids in raw_evidence_ids_by_module.items()
+    }
+
     evidence_clusters = _build_evidence_clusters(evidence_items)
-    quality_snapshot = _build_quality_snapshot(evidence_items, evidence_clusters, citecheck_payload)
+    quality_snapshot = _build_quality_snapshot(
+        evidence_items,
+        evidence_clusters,
+        citecheck_payload,
+        raw_evidence_count=raw_evidence_count,
+    )
 
     evidence_cluster_ids_by_evidence_id = {
         evidence_id: cluster.cluster_id
@@ -1382,24 +1453,30 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
     citation_summary = citecheck_payload.get("summary", {})
     uncertain = citation_summary.get("uncertain", 0)
     not_found = citation_summary.get("not_found", 0)
-    uncertain_evidence_ids = [
-        evidence_id
-        for evidence_id, check in zip(
-            evidence_ids_by_module["citation_verify"],
-            citecheck_payload.get("checks", []),
-            strict=False,
-        )
-        if check.get("status") == "uncertain"
-    ]
-    not_found_evidence_ids = [
-        evidence_id
-        for evidence_id, check in zip(
-            evidence_ids_by_module["citation_verify"],
-            citecheck_payload.get("checks", []),
-            strict=False,
-        )
-        if check.get("status") == "not_found"
-    ]
+    uncertain_evidence_ids = _rewrite_evidence_ids(
+        [
+            evidence_id
+            for evidence_id, check in zip(
+                raw_evidence_ids_by_module["citation_verify"],
+                citecheck_payload.get("checks", []),
+                strict=False,
+            )
+            if check.get("status") == "uncertain"
+        ],
+        dedupe_result.old_id_to_retained_id,
+    )
+    not_found_evidence_ids = _rewrite_evidence_ids(
+        [
+            evidence_id
+            for evidence_id, check in zip(
+                raw_evidence_ids_by_module["citation_verify"],
+                citecheck_payload.get("checks", []),
+                strict=False,
+            )
+            if check.get("status") == "not_found"
+        ],
+        dedupe_result.old_id_to_retained_id,
+    )
     if uncertain:
         related_cluster_ids = _cluster_ids_for_evidence_ids(
             uncertain_evidence_ids,
@@ -1616,6 +1693,8 @@ def _build_quality_snapshot(
     evidence_items: list[EvidenceItem],
     evidence_clusters: list[EvidenceCluster],
     citecheck_payload: Mapping[str, Any],
+    *,
+    raw_evidence_count: int | None = None,
 ) -> QualitySnapshot:
     evidence_items_by_id = {item.evidence_id: item for item in evidence_items}
     source_class_counts: dict[str, int] = {}
@@ -1677,7 +1756,9 @@ def _build_quality_snapshot(
         evidence_item_count=evidence_item_count,
         evidence_cluster_count=evidence_cluster_count,
         grouped_evidence_count=max(0, evidence_item_count - evidence_cluster_count),
-        raw_evidence_count=evidence_item_count,
+        raw_evidence_count=raw_evidence_count
+        if raw_evidence_count is not None
+        else evidence_item_count,
         normalized_authority_count=normalized_authority_count,
         duplicate_authority_count=max(0, evidence_item_count - normalized_authority_count),
         provenance_link_count=provenance_link_count,
@@ -2185,6 +2266,18 @@ def _normalize_cluster_url(url: str) -> str:
     path = re.sub(r"/+", "/", (parsed.path or "").rstrip("/"))
     normalized = f"{hostname}{path}".strip("/")
     return normalized.lower()
+
+
+def _rewrite_evidence_ids(
+    evidence_ids: list[str],
+    old_id_to_retained_id: Mapping[str, str],
+) -> list[str]:
+    rewritten: list[str] = []
+    for evidence_id in evidence_ids:
+        retained_id = old_id_to_retained_id.get(evidence_id, evidence_id)
+        if retained_id and retained_id not in rewritten:
+            rewritten.append(retained_id)
+    return rewritten
 
 
 def _cluster_ids_for_evidence_ids(

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -5,11 +5,15 @@ import copy
 import pytest
 from pydantic import ValidationError
 
-from tests.provenance_integrity import assert_audit_snapshot_provenance_integrity
+from tests.provenance_integrity import (
+    assert_all_current_provenance_surfaces,
+    assert_audit_snapshot_provenance_integrity,
+)
 from war_room.export_md import render_markdown_memo
 from war_room.models import (
     CaseIntake,
     QuerySpec,
+    _dedupe_evidence_items_for_audit_snapshot,
     adapt_citation_verify_pack,
     carrier_doc_pack_to_evidence_items,
     caselaw_pack_to_evidence_items,
@@ -126,6 +130,19 @@ def _sample_payloads():
     query_plan = [QuerySpec(module="weather", query="test query", category="test")]
 
     return intake, weather, carrier, caselaw, citecheck, query_plan
+
+
+def _add_duplicate_weather_source(weather: dict) -> None:
+    weather["sources"][0]["url"] = "https://www.weather.gov/r/?utm_source=newsletter"
+    weather["sources"].append(
+        {
+            **weather["sources"][0],
+            "url": "https://weather.gov/r",
+        }
+    )
+    weather["key_observations"].append(
+        "Candidate-only summary should not be merged into the retained row."
+    )
 
 
 def test_weather_evidence_adapter_returns_stable_ids_for_repeated_payloads():
@@ -727,6 +744,147 @@ def test_dedupe_evidence_items_keeps_distinct_urls_and_review_conflicts():
         "carrier-doc-id-2",
         "carrier-doc-review-required",
     ]
+
+
+def test_audit_snapshot_dedupe_result_maps_same_module_duplicates():
+    _, weather, _, _, _, _ = _sample_payloads()
+    _add_duplicate_weather_source(weather)
+    items = weather_brief_to_evidence_items(weather)
+    retained_id = items[0].evidence_id
+    duplicate_id = items[1].evidence_id
+
+    result = _dedupe_evidence_items_for_audit_snapshot(items)
+
+    assert [item.evidence_id for item in result.retained_items] == [retained_id]
+    assert result.old_id_to_retained_id == {
+        retained_id: retained_id,
+        duplicate_id: retained_id,
+    }
+    assert result.removed_duplicate_ids == [duplicate_id]
+    assert result.retained_id_to_duplicate_ids == {retained_id: [duplicate_id]}
+
+
+def test_audit_snapshot_dedupe_result_forbids_cross_module_url_citation_collapse():
+    _, _, _, caselaw, citecheck, _ = _sample_payloads()
+    case_item = caselaw_pack_to_evidence_items(caselaw)[0].model_copy(
+        update={
+            "url": "https://www.flcourts.gov/case/123?utm_source=alert",
+            "badge": "official",
+            "source_reason": "official source",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+            "issue": None,
+        }
+    )
+    citation_item = citation_verify_pack_to_evidence_items(citecheck)[0].model_copy(
+        update={
+            "url": "https://flcourts.gov/case/123",
+            "badge": "official",
+            "source_reason": "official source",
+            "source_class": "court_opinion",
+            "source_tier": "official",
+            "is_primary_authority": True,
+        }
+    )
+
+    result = _dedupe_evidence_items_for_audit_snapshot([case_item, citation_item])
+
+    assert [item.evidence_id for item in result.retained_items] == [
+        case_item.evidence_id,
+        citation_item.evidence_id,
+    ]
+    assert result.removed_duplicate_ids == []
+    assert result.old_id_to_retained_id == {
+        case_item.evidence_id: case_item.evidence_id,
+        citation_item.evidence_id: citation_item.evidence_id,
+    }
+
+
+def test_run_audit_snapshot_rewrites_same_module_duplicate_references_across_surfaces():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    _add_duplicate_weather_source(weather)
+    weather["warnings"] = ["County-specific weather corroboration is limited."]
+    raw_weather_items = weather_brief_to_evidence_items(weather)
+    retained_weather_id = raw_weather_items[0].evidence_id
+    removed_weather_id = raw_weather_items[1].evidence_id
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+    markdown = render_markdown_memo(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    evidence_ids = {item.evidence_id for item in snapshot.evidence_items}
+    weather_claim = next(
+        claim for claim in snapshot.memo_claims if claim.claim_id == "weather-corroboration"
+    )
+    weather_event = next(
+        event for event in snapshot.review_events if event.event_id == "weather-warning-1"
+    )
+
+    assert retained_weather_id in evidence_ids
+    assert removed_weather_id not in evidence_ids
+    assert weather_claim.evidence_ids == [retained_weather_id]
+    assert weather_event.related_evidence_ids == [retained_weather_id]
+    assert snapshot.quality_snapshot.raw_evidence_count == 5
+    assert snapshot.quality_snapshot.evidence_item_count == 4
+    assert removed_weather_id not in markdown
+    assert_all_current_provenance_surfaces(snapshot, markdown)
+
+
+def test_run_audit_snapshot_keeps_caselaw_and_citation_rows_distinct_when_checks_dedupe():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    citecheck["checks"][0]["status"] = "uncertain"
+    citecheck["checks"][0]["badge"] = "warning"
+    citecheck["checks"][0]["note"] = "Found on reviewable source."
+    citecheck["checks"].append(dict(citecheck["checks"][0]))
+    citecheck["summary"] = {"total": 2, "verified": 0, "uncertain": 2, "not_found": 0}
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
+    raw_citation_items = citation_verify_pack_to_evidence_items(citecheck)
+    retained_citation_id = raw_citation_items[0].evidence_id
+    removed_citation_id = raw_citation_items[1].evidence_id
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    evidence_ids = {item.evidence_id for item in snapshot.evidence_items}
+    assert caselaw_evidence_id in evidence_ids
+    assert retained_citation_id in evidence_ids
+    assert removed_citation_id not in evidence_ids
+    shared_cluster = next(
+        cluster
+        for cluster in snapshot.evidence_clusters
+        if caselaw_evidence_id in cluster.evidence_ids
+        and retained_citation_id in cluster.evidence_ids
+    )
+    citation_event = next(
+        event for event in snapshot.review_events if event.event_id == "citation-uncertain"
+    )
+    assert shared_cluster.modules == ["caselaw", "citation_verify"]
+    assert citation_event.related_evidence_ids == [retained_citation_id]
+    assert citation_event.related_cluster_ids == [shared_cluster.cluster_id]
+    assert citation_event.detail == "2 citation checks are uncertain."
+    assert snapshot.quality_snapshot.raw_evidence_count == 5
+    assert snapshot.quality_snapshot.evidence_item_count == 4
+    assert_audit_snapshot_provenance_integrity(snapshot)
 
 
 def test_citation_verify_summary_validation_rejects_bad_totals():


### PR DESCRIPTION
## Summary
- Integrates deterministic same-module evidence dedupe into audit snapshot assembly after all current evidence adapter rows are created.
- Adds an internal runtime-local dedupe result with `retained_items`, `old_id_to_retained_id`, `removed_duplicate_ids`, and `retained_id_to_duplicate_ids`.
- Rewrites module evidence IDs, clusters, memo claims, citation review events, read-model/export-facing references, and quality counts through retained IDs.

## Exact scope
- Runtime seam: `run_audit_snapshot_from_memo_input(...)` and nearby internal helpers in `src/war_room/models.py`.
- Tests: focused memo-contract coverage for deterministic retained IDs, same-module collapse, old-to-retained remapping, cross-module non-collapse, citation review remapping, markdown/read-model provenance integrity, and raw-vs-retained counts.
- Session log: records the validation trail and count decision.

## Intentionally not changed
- No persistence, API, UI/dashboard, auth/users/sessions, queues/workers/background runtime, schema expansion, fuzzy/ML clustering, AI scoring, live retrieval changes, citation verification behavior changes, or golden snapshot refresh.
- No claim that the V2 evidence graph is complete.
- The public helper `dedupe_evidence_items(...)` keeps its existing behavior; audit snapshot integration applies the same-module-only policy separately.

## Counts changed
- Committed fixture lanes: no same-module duplicate collapse observed; raw and retained evidence counts remained equal across all five fixture cases.
- Focused synthetic duplicate tests intentionally show the new count contract: `raw_evidence_count=5` and `evidence_item_count=4` after same-module collapse.

## Cross-module policy
- Confirmed: cross-module caselaw and citation-verification rows that share URL/citation still do not collapse in audit snapshot integration.
- Citation verification rows remain distinct from caselaw rows; they may still share an evidence cluster.

## Provenance-integrity harness
- Confirmed passing. The focused suite includes the existing provenance-integrity harness across audit snapshot, Evidence Board, Issue Workspace, Memo Composer, Markdown export, and committed fixture preflight surfaces.

## Validation
- `git diff --check` -> passed.
- `python -m pytest tests/test_memo_contracts.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export.py tests/test_preflight.py -q` -> `87 passed in 6.29s`.
- `python -m pytest -q` -> `491 passed in 21.40s`.
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `491 passed in 22.10s`.

References #12.