### PR TITLE
[codex] Cover not_found citation dedupe visibility

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3272,3 +3272,39 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `491 passed in 22.10s`; verify manifest written under
     `runs/verify/2026-05-20_codex-12-same-module-audit-dedupe_20260520t220446z.json`.
+
+## Session 143 - Issue 137 Citation Dedupe Visibility Follow-Up
+Date: 2026-05-20
+Status: Complete
+
+- Added the narrow issue `#137` follow-up after PR `#136` merged the
+  same-module audit snapshot dedupe integration.
+- What changed:
+  - Added a focused regression for duplicate `citation_verify` rows with
+    `status="not_found"` collapsing within the same module.
+  - Proved the `citation-not-found` review event rewrites the removed citation
+    evidence ID to the retained citation evidence ID and keeps its related
+    cluster ID resolvable after the rewrite.
+  - Kept caselaw and citation-verification rows distinct across modules while
+    allowing them to share a related evidence cluster.
+  - Added a reviewer-facing Markdown Quality Snapshot line:
+    `Evidence retention: <raw> raw/pre-dedupe / <retained> retained/exported`.
+- Decisions added:
+  - Markdown output now exposes raw/pre-dedupe versus retained/exported
+    evidence counts in the existing Quality Snapshot appendix.
+- Decisions not added:
+  - no cross-module evidence collapse, retained-row duplicate/source metadata
+    schema, persistence, API, UI/dashboard, auth/users/sessions,
+    queues/workers/background runtime, fuzzy/ML clustering, AI scoring, live
+    retrieval change, citation verification behavior change, broad golden
+    snapshot refresh, or claim that the V2 evidence graph is complete was
+    added.
+- Validation:
+  - `python -m pytest tests/test_memo_contracts.py::test_run_audit_snapshot_rewrites_not_found_duplicate_citation_review_event tests/test_export.py::test_render_quality_snapshot_surfaces_raw_vs_retained_evidence_counts -q`
+    -> `2 passed in 18.75s`.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_export.py -q`
+    -> `63 passed in 16.64s`.
+  - `python -m pytest -q` -> `493 passed in 48.96s`.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `493 passed in 47.93s`; verify manifest written under
+    `runs/verify/2026-05-20_codex-137-not-found-dedupe-visibility_20260520t224832z.json`.

--- a/src/war_room/export_md.py
+++ b/src/war_room/export_md.py
@@ -396,6 +396,10 @@ def _append_quality_snapshot(lines: list[str], quality_snapshot: Any) -> None:
         f"({quality_snapshot.grouped_evidence_count} grouped)"
     )
     lines.append(
+        f"- Evidence retention: {quality_snapshot.raw_evidence_count} raw/pre-dedupe / "
+        f"{quality_snapshot.evidence_item_count} retained/exported"
+    )
+    lines.append(
         f"- Canonical authorities: {quality_snapshot.normalized_authority_count} "
         f"({quality_snapshot.duplicate_authority_count} duplicates collapsed, "
         f"{quality_snapshot.provenance_link_count} provenance links)"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -330,6 +330,21 @@ def test_render_shows_canonical_authority_and_alternate_counts():
     assert "Alternate aligned candidates: 2" in md
 
 
+def test_render_quality_snapshot_surfaces_raw_vs_retained_evidence_counts():
+    intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
+    weather["sources"][0]["url"] = "https://www.weather.gov/r/?utm_source=newsletter"
+    weather["sources"].append(
+        {
+            **weather["sources"][0],
+            "url": "https://weather.gov/r",
+        }
+    )
+
+    md = render_markdown_memo(intake, weather, carrier, caselaw, citecheck, queries)
+
+    assert "- Evidence retention: 5 raw/pre-dedupe / 4 retained/exported" in md
+
+
 def test_render_sanitizes_multiline_export_text_and_backfills_citation_reasoning():
     intake, weather, carrier, caselaw, citecheck, queries = _sample_data()
     weather["key_observations"] = ["Line one\nLine two [Home] | extra"]

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -887,6 +887,58 @@ def test_run_audit_snapshot_keeps_caselaw_and_citation_rows_distinct_when_checks
     assert_audit_snapshot_provenance_integrity(snapshot)
 
 
+def test_run_audit_snapshot_rewrites_not_found_duplicate_citation_review_event():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    citecheck["checks"][0]["status"] = "not_found"
+    citecheck["checks"][0]["badge"] = "not_found"
+    citecheck["checks"][0]["note"] = "No matching source found."
+    citecheck["checks"].append(dict(citecheck["checks"][0]))
+    citecheck["summary"] = {"total": 2, "verified": 0, "uncertain": 0, "not_found": 2}
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
+    raw_citation_items = citation_verify_pack_to_evidence_items(citecheck)
+    retained_citation_id = raw_citation_items[0].evidence_id
+    removed_citation_id = raw_citation_items[1].evidence_id
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+    markdown = render_markdown_memo(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    evidence_ids = {item.evidence_id for item in snapshot.evidence_items}
+    assert caselaw_evidence_id in evidence_ids
+    assert retained_citation_id in evidence_ids
+    assert removed_citation_id not in evidence_ids
+    shared_cluster = next(
+        cluster
+        for cluster in snapshot.evidence_clusters
+        if caselaw_evidence_id in cluster.evidence_ids
+        and retained_citation_id in cluster.evidence_ids
+    )
+    citation_event = next(
+        event for event in snapshot.review_events if event.event_id == "citation-not-found"
+    )
+    assert shared_cluster.modules == ["caselaw", "citation_verify"]
+    assert citation_event.related_evidence_ids == [retained_citation_id]
+    assert citation_event.related_cluster_ids == [shared_cluster.cluster_id]
+    assert citation_event.detail == "2 citation checks were not found on reviewed sources."
+    assert snapshot.quality_snapshot.raw_evidence_count == 5
+    assert snapshot.quality_snapshot.evidence_item_count == 4
+    assert removed_citation_id not in markdown
+    assert_all_current_provenance_surfaces(snapshot, markdown)
+
+
 def test_citation_verify_summary_validation_rejects_bad_totals():
     _, _, _, _, citecheck, _ = _sample_payloads()
     citecheck["summary"] = {"total": 99, "verified": 1, "uncertain": 0, "not_found": 0}


### PR DESCRIPTION
Closes #137

## Summary
- Added a focused regression for duplicate `citation_verify` rows with `status="not_found"` collapsing within the same module.
- Proved the `citation-not-found` review event rewrites removed evidence IDs to the retained citation evidence ID and keeps related cluster IDs resolvable after the rewrite.
- Added a concise session-log entry for the follow-up.

## Markdown output changed
Yes. The existing Markdown Quality Snapshot appendix now includes one reviewer-facing count line:

`Evidence retention: <raw> raw/pre-dedupe / <retained> retained/exported`

No broad golden snapshot refresh was needed; the focused export test covers the exact deterministic line.

## Validation
- `git diff --check` -> passed
- `python -m pytest tests/test_memo_contracts.py tests/test_export.py -q` -> `63 passed in 16.64s`
- `python -m pytest -q` -> `493 passed in 48.96s`
- `python -m war_room --verify` -> passed; embedded `pytest -q` reported `493 passed in 47.93s`; verify manifest: `runs/verify/2026-05-20_codex-137-not-found-dedupe-visibility_20260520t224832z.json`

## Coverage confirmations
- `not_found` duplicate citation review-event remapping is covered by `test_run_audit_snapshot_rewrites_not_found_duplicate_citation_review_event`.
- Related cluster IDs are asserted against the retained citation evidence row and the shared caselaw/citation cluster.
- Cross-module caselaw/citation-verify collapse remains out of scope; rows stay distinct and may only share a cluster.

## Explicit non-goals preserved
- No cross-module evidence collapse.
- No retained-row duplicate/source metadata schema.
- No persistence, API, UI/dashboard, auth/users/sessions, queues/workers/background runtime.
- No fuzzy/ML clustering, AI scoring, live retrieval changes, or citation verification behavior changes.
- No broad golden snapshot refresh.
- No claim that the V2 evidence graph is complete.