### PR TITLE
Add same-module evidence dedupe trace metadata

### DIFF
--- a/docs/SESSION_LOG.md
+++ b/docs/SESSION_LOG.md
@@ -3346,3 +3346,41 @@ Status: Complete
   - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
     `493 passed in 24.74s`; verify manifest written under
     `runs/verify/2026-05-28_codex-139-dedupe-metadata-decision_20260528t172144z.json`.
+
+## Session 146 - Issue 142 Same-Module Dedupe Trace Metadata
+Date: 2026-06-08
+Status: Complete
+
+- Added the narrow issue `#142` follow-up for reviewer-visible same-module
+  evidence dedupe trace metadata in audit snapshots.
+- What changed:
+  - Added `EvidenceDedupeTrace` as a separate audit metadata object on
+    `RunAuditSnapshot`.
+  - Emitted one trace for each same-module evidence row removed by audit
+    snapshot dedupe, preserving old ID, retained ID, module, evidence type,
+    source role, dedupe key/reason, URL/citation/authority fields, badge,
+    source class/tier/reason fields, issue fields, primary-authority flags,
+    and review-required flags where available.
+  - Kept retained `EvidenceItem` rows unchanged and kept markdown/export
+    provenance on retained IDs only.
+  - Added focused coverage for same-module trace emission, cross-module
+    no-collapse/no-trace behavior, backward-compatible payload validation, and
+    existing audit/export provenance integrity.
+- Decisions added:
+  - Same-module removed duplicate visibility now lives in
+    `RunAuditSnapshot.dedupe_traces`.
+- Decisions not added:
+  - no cross-module evidence collapse, citation behavior change, retrieval
+    behavior change, source ranking change, markdown appendix change,
+    persistence, API, UI/dashboard, auth, queues/workers, fuzzy/ML clustering,
+    AI scoring, live retrieval, new provider behavior, or broad evidence graph
+    refactor was added.
+- Validation:
+  - `python -m pytest tests/test_memo_contracts.py -q`
+    -> `46 passed in 0.46s`.
+  - `python -m pytest tests/test_memo_contracts.py tests/test_export.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export_history.py tests/test_preflight.py -q`
+    -> `97 passed in 2.80s`.
+  - `git diff --check` -> passed.
+  - `python -m war_room --verify` -> passed; embedded `pytest -q` reported
+    `496 passed in 9.38s`; verify manifest written under
+    `runs/verify/2026-06-08_codex-142-evidence-dedupe-traces_20260608t184600z.json`.

--- a/src/war_room/__init__.py
+++ b/src/war_room/__init__.py
@@ -56,6 +56,7 @@ _EXPORTS = {
     "CaseLawPack": "war_room.models",
     "CitationVerifyPack": "war_room.models",
     "EvidenceCluster": "war_room.models",
+    "EvidenceDedupeTrace": "war_room.models",
     "EvidenceItem": "war_room.models",
     "LegalIssue": "war_room.models",
     "ExportArtifact": "war_room.models",

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -1358,15 +1358,16 @@ def _dedupe_evidence_items_with_result(
                 retained_match.evidence_id,
                 [],
             ).append(item.evidence_id)
-            dedupe_traces.append(
-                _evidence_dedupe_trace(
-                    trace_index=len(dedupe_traces) + 1,
-                    retained=retained_match,
-                    removed=item,
-                    dedupe_key=dedupe_key,
-                    same_module_only=same_module_only,
+            if same_module_only:
+                dedupe_traces.append(
+                    _evidence_dedupe_trace(
+                        trace_index=len(dedupe_traces) + 1,
+                        retained=retained_match,
+                        removed=item,
+                        dedupe_key=dedupe_key,
+                        same_module_only=same_module_only,
+                    )
                 )
-            )
             continue
 
         key_retained_items.append(item)

--- a/src/war_room/models.py
+++ b/src/war_room/models.py
@@ -523,6 +523,41 @@ class EvidenceCluster(BaseModel):
     review_required: bool = False
 
 
+class EvidenceDedupeTrace(BaseModel):
+    """Audit trace for an evidence row removed by same-module dedupe."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    trace_id: str = Field(min_length=1)
+    old_evidence_id: str = Field(min_length=1)
+    retained_evidence_id: str = Field(min_length=1)
+    module: Literal["weather", "carrier", "caselaw", "citation_verify"]
+    evidence_type: str = Field(min_length=1)
+    source_role: str | None = None
+    dedupe_key: str = Field(min_length=1)
+    dedupe_reason: str = Field(min_length=1)
+    old_url: str | None = None
+    retained_url: str | None = None
+    old_citation: str | None = None
+    retained_citation: str | None = None
+    old_authority_key: str | None = None
+    retained_authority_key: str | None = None
+    old_badge: str | None = None
+    retained_badge: str | None = None
+    old_source_reason: str | None = None
+    retained_source_reason: str | None = None
+    old_source_class: str | None = None
+    retained_source_class: str | None = None
+    old_source_tier: str | None = None
+    retained_source_tier: str | None = None
+    old_issue: str | None = None
+    retained_issue: str | None = None
+    old_is_primary_authority: bool = False
+    retained_is_primary_authority: bool = False
+    old_review_required: bool = False
+    retained_review_required: bool = False
+
+
 class QualitySnapshot(BaseModel):
     """Lightweight structured retrieval-quality telemetry for one memo run."""
 
@@ -623,6 +658,7 @@ class RunAuditSnapshot(BaseModel):
     run_events: list[RunEvent] = Field(default_factory=list)
     evidence_items: list[EvidenceItem] = Field(default_factory=list)
     evidence_clusters: list[EvidenceCluster] = Field(default_factory=list)
+    dedupe_traces: list[EvidenceDedupeTrace] = Field(default_factory=list)
     memo_claims: list[MemoClaim] = Field(default_factory=list)
     review_events: list[ReviewEvent] = Field(default_factory=list)
     quality_snapshot: QualitySnapshot = Field(default_factory=QualitySnapshot)
@@ -640,6 +676,7 @@ class _EvidenceDedupeIntegrationResult:
     old_id_to_retained_id: dict[str, str]
     removed_duplicate_ids: list[str]
     retained_id_to_duplicate_ids: dict[str, list[str]]
+    dedupe_traces: list[EvidenceDedupeTrace]
 
 
 class EvidenceBoardItemPreview(BaseModel):
@@ -1293,6 +1330,7 @@ def _dedupe_evidence_items_with_result(
     old_id_to_retained_id: dict[str, str] = {}
     removed_duplicate_ids: list[str] = []
     retained_id_to_duplicate_ids: dict[str, list[str]] = {}
+    dedupe_traces: list[EvidenceDedupeTrace] = []
 
     for item in evidence_items:
         key = _dedupe_key_for_evidence_item(item)
@@ -1300,6 +1338,7 @@ def _dedupe_evidence_items_with_result(
             retained_result_items.append(item)
             old_id_to_retained_id[item.evidence_id] = item.evidence_id
             continue
+        dedupe_key = key
         if same_module_only:
             key = (item.module, *key)
 
@@ -1319,6 +1358,15 @@ def _dedupe_evidence_items_with_result(
                 retained_match.evidence_id,
                 [],
             ).append(item.evidence_id)
+            dedupe_traces.append(
+                _evidence_dedupe_trace(
+                    trace_index=len(dedupe_traces) + 1,
+                    retained=retained_match,
+                    removed=item,
+                    dedupe_key=dedupe_key,
+                    same_module_only=same_module_only,
+                )
+            )
             continue
 
         key_retained_items.append(item)
@@ -1330,7 +1378,77 @@ def _dedupe_evidence_items_with_result(
         old_id_to_retained_id=old_id_to_retained_id,
         removed_duplicate_ids=removed_duplicate_ids,
         retained_id_to_duplicate_ids=retained_id_to_duplicate_ids,
+        dedupe_traces=dedupe_traces,
     )
+
+
+def _evidence_dedupe_trace(
+    *,
+    trace_index: int,
+    retained: EvidenceItem,
+    removed: EvidenceItem,
+    dedupe_key: tuple[str, ...],
+    same_module_only: bool,
+) -> EvidenceDedupeTrace:
+    return EvidenceDedupeTrace(
+        trace_id=f"dedupe-trace-{trace_index}",
+        old_evidence_id=removed.evidence_id,
+        retained_evidence_id=retained.evidence_id,
+        module=removed.module,
+        evidence_type=removed.evidence_type,
+        source_role=_evidence_source_role(removed),
+        dedupe_key=_dedupe_key_to_trace_token(dedupe_key),
+        dedupe_reason=_dedupe_reason_for_key(
+            dedupe_key,
+            same_module_only=same_module_only,
+        ),
+        old_url=removed.url,
+        retained_url=retained.url,
+        old_citation=removed.citation,
+        retained_citation=retained.citation,
+        old_authority_key=removed.authority_key,
+        retained_authority_key=retained.authority_key,
+        old_badge=removed.badge,
+        retained_badge=retained.badge,
+        old_source_reason=removed.source_reason,
+        retained_source_reason=retained.source_reason,
+        old_source_class=removed.source_class,
+        retained_source_class=retained.source_class,
+        old_source_tier=removed.source_tier,
+        retained_source_tier=retained.source_tier,
+        old_issue=removed.issue,
+        retained_issue=retained.issue,
+        old_is_primary_authority=removed.is_primary_authority,
+        retained_is_primary_authority=retained.is_primary_authority,
+        old_review_required=removed.review_required,
+        retained_review_required=retained.review_required,
+    )
+
+
+def _evidence_source_role(item: EvidenceItem) -> str:
+    return item.source_class or item.source_tier or item.evidence_type
+
+
+def _dedupe_key_to_trace_token(dedupe_key: tuple[str, ...]) -> str:
+    return ":".join(str(part) for part in dedupe_key if str(part))
+
+
+def _dedupe_reason_for_key(
+    dedupe_key: tuple[str, ...],
+    *,
+    same_module_only: bool,
+) -> str:
+    key_type = dedupe_key[0] if dedupe_key else "unknown"
+    scope = "same-module " if same_module_only else ""
+    if key_type == "url":
+        return f"{scope}normalized URL match"
+    if key_type == "citation":
+        return f"{scope}normalized citation match"
+    if key_type == "authority":
+        return f"{scope}normalized authority match"
+    if key_type == "title":
+        return f"{scope}module-scoped title match"
+    return f"{scope}dedupe key match"
 
 
 def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditSnapshot:
@@ -1608,6 +1726,7 @@ def run_audit_snapshot_from_memo_input(memo_input: MemoRenderInput) -> RunAuditS
         run_events=run_events,
         evidence_items=evidence_items,
         evidence_clusters=evidence_clusters,
+        dedupe_traces=dedupe_result.dedupe_traces,
         memo_claims=memo_claims,
         review_events=review_events,
         quality_snapshot=quality_snapshot,

--- a/tests/test_memo_contracts.py
+++ b/tests/test_memo_contracts.py
@@ -762,6 +762,25 @@ def test_audit_snapshot_dedupe_result_maps_same_module_duplicates():
     }
     assert result.removed_duplicate_ids == [duplicate_id]
     assert result.retained_id_to_duplicate_ids == {retained_id: [duplicate_id]}
+    assert len(result.dedupe_traces) == 1
+    trace = result.dedupe_traces[0]
+    assert trace.old_evidence_id == duplicate_id
+    assert trace.retained_evidence_id == retained_id
+    assert trace.module == "weather"
+    assert trace.evidence_type == "weather_source"
+    assert trace.dedupe_key == "url:weather.gov/r"
+    assert trace.dedupe_reason == "same-module normalized URL match"
+    assert trace.old_url == "https://weather.gov/r"
+    assert trace.retained_url == "https://www.weather.gov/r/?utm_source=newsletter"
+    assert trace.old_source_reason == "Official source"
+    assert trace.retained_source_reason == "Official source"
+    assert trace.old_source_tier == trace.retained_source_tier == "official"
+    assert trace.old_issue is None
+    assert trace.retained_issue is None
+    assert trace.old_is_primary_authority is False
+    assert trace.retained_is_primary_authority is False
+    assert trace.old_review_required is False
+    assert trace.retained_review_required is False
 
 
 def test_audit_snapshot_dedupe_result_forbids_cross_module_url_citation_collapse():
@@ -799,6 +818,90 @@ def test_audit_snapshot_dedupe_result_forbids_cross_module_url_citation_collapse
         case_item.evidence_id: case_item.evidence_id,
         citation_item.evidence_id: citation_item.evidence_id,
     }
+    assert result.dedupe_traces == []
+
+
+def test_run_audit_snapshot_emits_same_module_dedupe_trace_metadata():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    _add_duplicate_weather_source(weather)
+    raw_weather_items = weather_brief_to_evidence_items(weather)
+    retained_weather_id = raw_weather_items[0].evidence_id
+    removed_weather_id = raw_weather_items[1].evidence_id
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+    payload = run_audit_snapshot_to_payload(snapshot)
+
+    assert [trace.old_evidence_id for trace in snapshot.dedupe_traces] == [
+        removed_weather_id
+    ]
+    trace = snapshot.dedupe_traces[0]
+    assert trace.retained_evidence_id == retained_weather_id
+    assert trace.module == "weather"
+    assert trace.evidence_type == "weather_source"
+    assert trace.source_role == trace.old_source_class
+    assert trace.dedupe_key == "url:weather.gov/r"
+    assert trace.dedupe_reason == "same-module normalized URL match"
+    assert trace.old_url == "https://weather.gov/r"
+    assert trace.retained_url == "https://www.weather.gov/r/?utm_source=newsletter"
+    assert trace.old_badge == trace.retained_badge == "official"
+    assert trace.old_source_reason == trace.retained_source_reason == "Official source"
+    assert trace.old_source_tier == trace.retained_source_tier == "official"
+    assert trace.old_issue is None
+    assert trace.retained_issue is None
+    assert trace.old_is_primary_authority is False
+    assert trace.retained_is_primary_authority is False
+    assert trace.old_review_required is False
+    assert trace.retained_review_required is False
+    assert payload["dedupe_traces"][0]["old_evidence_id"] == removed_weather_id
+    assert payload["dedupe_traces"][0]["retained_evidence_id"] == retained_weather_id
+    assert_audit_snapshot_provenance_integrity(snapshot)
+
+
+def test_run_audit_snapshot_accepts_payload_without_dedupe_traces_for_compatibility():
+    snapshot = run_audit_snapshot_from_parts(*_sample_payloads())
+    payload = run_audit_snapshot_to_payload(snapshot)
+    payload.pop("dedupe_traces")
+
+    normalized_payload = run_audit_snapshot_to_payload(payload)
+
+    assert normalized_payload["dedupe_traces"] == []
+
+
+def test_run_audit_snapshot_does_not_emit_cross_module_dedupe_traces():
+    intake, weather, carrier, caselaw, citecheck, query_plan = _sample_payloads()
+    caselaw_evidence_id = caselaw_pack_to_evidence_items(caselaw)[0].evidence_id
+    citation_evidence_id = (
+        citation_verify_pack_to_evidence_items(citecheck)[0].evidence_id
+    )
+
+    snapshot = run_audit_snapshot_from_parts(
+        intake,
+        weather,
+        carrier,
+        caselaw,
+        citecheck,
+        query_plan,
+    )
+
+    evidence_ids = {item.evidence_id for item in snapshot.evidence_items}
+    assert caselaw_evidence_id in evidence_ids
+    assert citation_evidence_id in evidence_ids
+    assert snapshot.dedupe_traces == []
+    assert snapshot.quality_snapshot.raw_evidence_count == 4
+    assert snapshot.quality_snapshot.evidence_item_count == 4
+    assert any(
+        caselaw_evidence_id in cluster.evidence_ids
+        and citation_evidence_id in cluster.evidence_ids
+        for cluster in snapshot.evidence_clusters
+    )
+    assert_audit_snapshot_provenance_integrity(snapshot)
 
 
 def test_run_audit_snapshot_rewrites_same_module_duplicate_references_across_surfaces():


### PR DESCRIPTION
Closes #142

Summary
- Adds EvidenceDedupeTrace as a separate audit-snapshot metadata object.
- Emits trace records when same-module audit snapshot dedupe removes an evidence row.
- Keeps retained EvidenceItem rows, citation behavior, retrieval behavior, source ranking, cross-module behavior, and markdown/export retained-ID provenance unchanged.

Changed files
- src/war_room/models.py: adds EvidenceDedupeTrace, records dedupe trace metadata during audit-only same-module dedupe, and attaches traces to RunAuditSnapshot.
- src/war_room/__init__.py: exports EvidenceDedupeTrace through the package lazy export map.
- tests/test_memo_contracts.py: adds focused same-module trace, cross-module no-trace/no-collapse, compatibility, and provenance integrity coverage.
- docs/SESSION_LOG.md: records the #142 implementation and validation trail.

Behavior added
- Trace records preserve old/removed evidence ID, retained evidence ID, module, evidence type/source role, dedupe key/reason, URL/citation/authority fields, badge/source tiering fields, issue fields, primary-authority flags, and review-required flags where available.
- Cross-module caselaw/citation-verification rows remain distinct and produce no same-module dedupe trace records.
- Existing audit/export provenance continues to resolve against retained evidence IDs only.

Tests run
- python -m pytest tests/test_memo_contracts.py -q -> 46 passed
- python -m pytest tests/test_memo_contracts.py tests/test_export.py tests/test_evidence_board.py tests/test_issue_workspace.py tests/test_memo_composer.py tests/test_export_history.py tests/test_preflight.py -q -> 97 passed
- git diff --check -> passed
- python -m war_room --verify -> passed; embedded pytest reported 496 passed

Known limitations
- Trace metadata is audit-snapshot metadata only; markdown output still lists retained evidence IDs only.
- This does not add cross-module dedupe/collapse, persistence, API, UI/dashboard, auth, queues/workers, fuzzy/ML clustering, AI scoring, live retrieval, or new provider behavior.